### PR TITLE
Add missing filter for CVE status, rename variables in package status…

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -31,7 +31,6 @@ functionality, but I don't know of a good way to do that right now.
 from webapp import auth
 from tests.helpers import transparent_decorator
 
-
 auth.authorization_required = transparent_decorator
 os.environ["DATABASE_URL"] = os.environ["TEST_DATABASE_URL"]
 
@@ -136,8 +135,8 @@ class TestRoutes(unittest.TestCase):
             "errors", []
         )
 
-    def test_cves_returns_422_for_non_existing_status(self):
-        response = self.client.get("/security/cves.json?status=no-exist")
+    def test_cves_returns_422_for_non_existing_package_status(self):
+        response = self.client.get("/security/cves.json?package_status=none")
 
         assert response.status_code == 422
         assert "Cannot find a status" in response.json["errors"]

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -461,7 +461,12 @@ CVEsParameters = {
         description="List of release codenames ",
         allow_none=True,
     ),
-    "status": List(
+    "status": String(
+        description="CVE status",
+        enum=["not-in-ubuntu", "active", "rejected"],
+        allow_none=True,
+    ),
+    "package_status": List(
         StatusStatuses(),
         description="List of statuses",
         allow_none=True,

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -81,7 +81,8 @@ def get_cves(**kwargs):
     offset = kwargs.get("offset", 0)
     component = kwargs.get("component")
     versions = kwargs.get("version")
-    statuses = kwargs.get("status")
+    status = kwargs.get("status")
+    package_status = kwargs.get("package_status")
     order_by = kwargs.get("order")
     show_hidden = kwargs.get("show_hidden", False)
 
@@ -102,6 +103,10 @@ def get_cves(**kwargs):
             )
         )
 
+    # filter by CVE status
+    if status:
+        cves_query = cves_query.filter(CVE.status == status)
+
     # build CVE statuses filter parameters
     parameters = []
 
@@ -113,10 +118,10 @@ def get_cves(**kwargs):
     if component:
         parameters.append(Status.component == component)
 
-    # filter by status and version
-    if _should_filter_by_version_and_status(statuses, versions):
+    # filter by package status and version
+    if _should_filter_by_version_and_status(package_status, versions):
         clean_versions = _get_clean_versions(versions)
-        clean_statuses = _get_clean_statuses(statuses)
+        clean_statuses = _get_clean_statuses(package_status)
 
         # filter for cves.statuses by status-version criteria
         # exclude stauses that don't satisfy any status-version criteria


### PR DESCRIPTION
## Done

- Added missing filter for CVE status
- Renamed variables in package status filter to ease confusion

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- Check that tests pass successfully 


## Issue / Card

Fixes https://github.com/canonical/ubuntu-com-security-api/issues/115