### PR TITLE
Add channel field to NoticePackage schema

### DIFF
--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -76,6 +76,7 @@ notice = {
                 "is_source": "false",
                 "name": "linux-oem",
                 "version": "4.15.0-1080.90",
+                "channel": "Test channel",
             }
         ],
     },
@@ -99,6 +100,7 @@ ssn_notice = {
                 "version": "4.15.0-1080.90",
                 "package_type": "golang",
                 "pocket": "soss",
+                "channel": "Test channel",
             }
         ],
     },

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -185,6 +185,7 @@ class NoticePackage(Schema):
     version_link = String(allow_none=True)
     pocket = Pocket()
     package_type = PackageType()
+    channel = String(allow_none=True)
 
 
 class NoticeSchema(Schema):


### PR DESCRIPTION
## Done

Add channel field to NoticePackage schema

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes https://github.com/canonical/ubuntu-com-security-api/issues/123
