### PR TITLE
Add new pocket options

### DIFF
--- a/migrations/versions/1e0a9c001320_add_new_pockets.py
+++ b/migrations/versions/1e0a9c001320_add_new_pockets.py
@@ -1,0 +1,53 @@
+"""empty message
+
+Revision ID: 1e0a9c001320
+Revises: 5c1128073317
+Create Date: 2023-03-28 17:09:04.546775
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1e0a9c001320'
+down_revision = '5c1128073317'
+branch_labels = None
+depends_on = None
+
+# Enum 'type' for PostgreSQL
+enum_name = 'pockets'
+# Set temporary enum 'type' for PostgreSQL
+tmp_enum_name = 'tmp_' + enum_name
+
+# Options for Enum
+old_options = ('security', 'updates', 'esm-infra', 'esm-apps')
+new_options = ('security', 'updates', 'esm-infra', 'esm-apps', 'soss', 'fips', 'fips-updates', 'ros-esm')
+
+# Create enum fields
+old_type = sa.Enum(*old_options, name=enum_name)
+new_type = sa.Enum(*new_options, name=enum_name)
+
+
+def upgrade():
+    # Rename current enum type to tmp_
+    op.execute('ALTER TYPE ' + enum_name + ' RENAME TO ' + tmp_enum_name)
+    # Create new enum type in db
+    new_type.create(op.get_bind())
+    # Update column to use new enum type
+    op.execute('ALTER TABLE status ALTER COLUMN pocket TYPE ' + enum_name + ' USING pocket::text::' + enum_name)
+    # Drop old enum type
+    op.execute('DROP TYPE ' + tmp_enum_name)
+
+
+def downgrade():
+    # Instantiate db query
+    status = sa.sql.table('status', sa.Column('pocket', new_type, nullable=False))
+    # Rename enum type to tmp_
+    op.execute('ALTER TYPE ' + enum_name + ' RENAME TO ' + tmp_enum_name)
+    # Create enum type using old values
+    old_type.create(op.get_bind())
+    # Set enum type as type for pocket column
+    op.execute('ALTER TABLE status ALTER COLUMN pocket TYPE ' + enum_name + ' USING pocket::text::' + enum_name)
+    # Drop temp enum type
+    op.execute('DROP TYPE ' + tmp_enum_name)

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -41,7 +41,7 @@ def make_models():
     )
 
     status = Status(
-        status="pending", cve=cve, package=package, release=release
+        status="pending", cve=cve, package=package, release=release,
     )
 
     notice = Notice(

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -41,7 +41,10 @@ def make_models():
     )
 
     status = Status(
-        status="pending", cve=cve, package=package, release=release,
+        status="pending",
+        cve=cve,
+        package=package,
+        release=release,
     )
 
     notice = Notice(

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -10,6 +10,7 @@ cve1 = {
                     "description": "",
                     "release_codename": "testrelease",
                     "status": "released",
+                    "pocket": "fips"
                 }
             ],
             "ubuntu": (

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -1,66 +1,66 @@
 cve1 = {
-    "id": "CVE-9999-0001",
-    "packages": [
+  "id": "CVE-9999-0001",
+  "packages": [
+    {
+      "debian": "https://tracker.debian.org/pkg/test_package_1",
+      "name": "test_package_1",
+      "source": "https://ubuntu.com/security/cve?package=test_package_1",
+      "statuses": [
         {
-            "debian": "https://tracker.debian.org/pkg/test_package_1",
-            "name": "test_package_1",
-            "source": "https://ubuntu.com/security/cve?package=test_package_1",
-            "statuses": [
-                {
-                    "description": "",
-                    "release_codename": "testrelease",
-                    "status": "released",
-                    "pocket": "fips"
-                }
-            ],
-            "ubuntu": (
-                "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-                "=any&searchon=sourcenames&keywords=test_package_1"
-            ),
+          "description": "",
+          "release_codename": "testrelease",
+          "status": "released",
+          "pocket": "fips"
         }
+      ],
+      "ubuntu": (
+          "https://packages.ubuntu.com/search?suite=all&section=all&arch"
+          "=any&searchon=sourcenames&keywords=test_package_1"
+      ),
+    }
     ],
-    "impact": {
-        "baseMetricV3": {
-            "cvssV3": {
-                "attackComplexity": "LOW",
-                "attackVector": "Local",
-                "availabilityImpact": "NONE",
-                "baseScore": 4.4,
-                "baseSeverity": "MEDIUM",
-                "confidentialityImpact": "HIGH",
-                "integrityImpact": "NONE",
-                "privilegesRequired": "HIGH",
-                "scope": "UNCHANGED",
-                "userInteraction": "NONE",
-                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
-                "version": "3.1",
-            },
-            "exploitabilityScore": 0.8,
-            "impactScore": 3.6,
-        }
-    },
+  "impact": {
+    "baseMetricV3": {
+      "cvssV3": {
+        "attackComplexity": "LOW",
+        "attackVector": "Local",
+        "availabilityImpact": "NONE",
+        "baseScore": 4.4,
+        "baseSeverity": "MEDIUM",
+        "confidentialityImpact": "HIGH",
+        "integrityImpact": "NONE",
+        "privilegesRequired": "HIGH",
+        "scope": "UNCHANGED",
+        "userInteraction": "NONE",
+        "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
+        "version": "3.1",
+      },
+      "exploitabilityScore": 0.8,
+      "impactScore": 3.6,
+    }
+  },
 }
 
 cve2 = {
-    "id": "CVE-9999-0002",
-    "packages": [
-        {
-            "debian": "https://tracker.debian.org/pkg/test_package_2",
-            "name": "test_package_2",
-            "source": "https://ubuntu.com/security/cve?package=test_package21",
-            "statuses": [
-                {
-                    "description": "",
-                    "release_codename": "testrelease",
-                    "status": "released",
-                }
-            ],
-            "ubuntu": (
-                "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-                "=any&searchon=sourcenames&keywords=test_package_2"
-            ),
-        }
-    ],
+  "id": "CVE-9999-0002",
+  "packages": [
+    {
+      "debian": "https://tracker.debian.org/pkg/test_package_2",
+      "name": "test_package_2",
+      "source": "https://ubuntu.com/security/cve?package=test_package21",
+      "statuses": [
+          {
+            "description": "",
+            "release_codename": "testrelease",
+            "status": "released",
+          }
+      ],
+      "ubuntu": (
+          "https://packages.ubuntu.com/search?suite=all&section=all&arch"
+          "=any&searchon=sourcenames&keywords=test_package_2"
+      ),
+    }
+  ],
 }
 
 notice = {
@@ -72,13 +72,13 @@ notice = {
     "references": [],
     "release_packages": {
         "testrelease": [
-            {
-                "description": "Linux kernel for OEM systems",
-                "is_source": "false",
-                "name": "linux-oem",
-                "version": "4.15.0-1080.90",
-                "channel": "Test channel",
-            }
+          {
+              "description": "Linux kernel for OEM systems",
+              "is_source": "false",
+              "name": "linux-oem",
+              "version": "4.15.0-1080.90",
+              "channel": "Test channel",
+          }
         ],
     },
     "summary": "Summary",

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -1,66 +1,66 @@
 cve1 = {
-  "id": "CVE-9999-0001",
-  "packages": [
-    {
-      "debian": "https://tracker.debian.org/pkg/test_package_1",
-      "name": "test_package_1",
-      "source": "https://ubuntu.com/security/cve?package=test_package_1",
-      "statuses": [
+    "id": "CVE-9999-0001",
+    "packages": [
         {
-          "description": "",
-          "release_codename": "testrelease",
-          "status": "released",
-          "pocket": "fips"
+            "debian": "https://tracker.debian.org/pkg/test_package_1",
+            "name": "test_package_1",
+            "source": "https://ubuntu.com/security/cve?package=test_package_1",
+            "statuses": [
+                {
+                    "description": "",
+                    "release_codename": "testrelease",
+                    "status": "released",
+                    "pocket": "fips",
+                }
+            ],
+            "ubuntu": (
+                "https://packages.ubuntu.com/search?suite=all&section=all&arch"
+                "=any&searchon=sourcenames&keywords=test_package_1"
+            ),
         }
-      ],
-      "ubuntu": (
-          "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-          "=any&searchon=sourcenames&keywords=test_package_1"
-      ),
-    }
     ],
-  "impact": {
-    "baseMetricV3": {
-      "cvssV3": {
-        "attackComplexity": "LOW",
-        "attackVector": "Local",
-        "availabilityImpact": "NONE",
-        "baseScore": 4.4,
-        "baseSeverity": "MEDIUM",
-        "confidentialityImpact": "HIGH",
-        "integrityImpact": "NONE",
-        "privilegesRequired": "HIGH",
-        "scope": "UNCHANGED",
-        "userInteraction": "NONE",
-        "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
-        "version": "3.1",
-      },
-      "exploitabilityScore": 0.8,
-      "impactScore": 3.6,
-    }
-  },
+    "impact": {
+        "baseMetricV3": {
+            "cvssV3": {
+                "attackComplexity": "LOW",
+                "attackVector": "Local",
+                "availabilityImpact": "NONE",
+                "baseScore": 4.4,
+                "baseSeverity": "MEDIUM",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "NONE",
+                "privilegesRequired": "HIGH",
+                "scope": "UNCHANGED",
+                "userInteraction": "NONE",
+                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N",
+                "version": "3.1",
+            },
+            "exploitabilityScore": 0.8,
+            "impactScore": 3.6,
+        }
+    },
 }
 
 cve2 = {
-  "id": "CVE-9999-0002",
-  "packages": [
-    {
-      "debian": "https://tracker.debian.org/pkg/test_package_2",
-      "name": "test_package_2",
-      "source": "https://ubuntu.com/security/cve?package=test_package21",
-      "statuses": [
-          {
-            "description": "",
-            "release_codename": "testrelease",
-            "status": "released",
-          }
-      ],
-      "ubuntu": (
-          "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-          "=any&searchon=sourcenames&keywords=test_package_2"
-      ),
-    }
-  ],
+    "id": "CVE-9999-0002",
+    "packages": [
+        {
+            "debian": "https://tracker.debian.org/pkg/test_package_2",
+            "name": "test_package_2",
+            "source": "https://ubuntu.com/security/cve?package=test_package21",
+            "statuses": [
+                {
+                    "description": "",
+                    "release_codename": "testrelease",
+                    "status": "released",
+                }
+            ],
+            "ubuntu": (
+                "https://packages.ubuntu.com/search?suite=all&section=all&arch"
+                "=any&searchon=sourcenames&keywords=test_package_2"
+            ),
+        }
+    ],
 }
 
 notice = {
@@ -72,13 +72,13 @@ notice = {
     "references": [],
     "release_packages": {
         "testrelease": [
-          {
-              "description": "Linux kernel for OEM systems",
-              "is_source": "false",
-              "name": "linux-oem",
-              "version": "4.15.0-1080.90",
-              "channel": "Test channel",
-          }
+            {
+                "description": "Linux kernel for OEM systems",
+                "is_source": "false",
+                "name": "linux-oem",
+                "version": "4.15.0-1080.90",
+                "channel": "Test channel",
+            }
         ],
     },
     "summary": "Summary",

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -252,7 +252,17 @@ class Status(db.Model):
         Enum("main", "universe", name="components"),
     )
     pocket = Column(
-        Enum("security", "updates", "esm-infra", "esm-apps", "fips", "fips-updates", "ros-esm", "soss", name="pockets"),
+        Enum(
+            "security",
+            "updates",
+            "esm-infra",
+            "esm-apps",
+            "fips",
+            "fips-updates",
+            "ros-esm",
+            "soss",
+            name="pockets",
+        ),
     )
 
     cve = relationship("CVE", back_populates="statuses")

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -252,7 +252,7 @@ class Status(db.Model):
         Enum("main", "universe", name="components"),
     )
     pocket = Column(
-        Enum("security", "updates", "esm-infra", "esm-apps", name="pockets"),
+        Enum("security", "updates", "esm-infra", "esm-apps", "fips", "fips-updates", "ros-esm", "soss", name="pockets"),
     )
 
     cve = relationship("CVE", back_populates="statuses")

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -24,6 +24,9 @@ POCKET_OPTIONS = [
     "esm-infra",
     "esm-apps",
     "soss",
+    "fips",
+    "fips-updates",
+    "ros-esm",
 ]
 
 PACKAGE_TYPE_OPTIONS = [


### PR DESCRIPTION
## Done

- Added new pocket options: `ros-esm`, `fips` and `fips-updates`
- Fix addition of previously added `soss` pocket

## Rationale 

As a part of the CVE overhaul we are going to start tracking the pocket options listed above. This will eventually replace the work done in [this PR](https://github.com/canonical/ubuntu.com/pull/12222). Additionally, during development we figured out that the soss pocket was never added to the db as an option because of a missing migration. This PR fixes that as well.  

## QA

- Passing tests is the QA for this, no further action is needed  


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2895
