### PR TITLE
Remove ability to query by CVE notes

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -115,7 +115,6 @@ def get_cves(**kwargs):
                 CVE.ubuntu_description.ilike(f"%{query}%"),
                 CVE.codename.ilike(f"%{query}%"),
                 CVE.mitigation.ilike(f"%{query}%"),
-                CVE.notes.ilike(f"%{query}%"),
             )
         )
 


### PR DESCRIPTION
## Done

- Temporarily disable ability to query by cve notes

## Rationale

This is breaking all text queries made against CVEs because for reasons that are still not clear to me CVE.notes["author"] and CVE.notes["note"] are different class types than all the other text based fields. I'm still investigating how to fix it, but for now this will at least allow users to submit queries.   

## QA

- See that tests pass
- I already checked that this works on the u.com codebase, but if you want to be _extra_ sure:
  - Run a local instance of this repo using `dotrun`. If you get errors `dotrun start-db` and then `dotrun` should work
  - Run a local instance of u.com
  - Replace [the base URL](https://github.com/canonical/ubuntu.com/blob/0fbf1f7e283a77e14d9370bedeb502e0af113dd5/webapp/security/views.py#L27) with `http://0.0.0.0:8030/security/`
  - Go to /security/cves on u.com and use the search bar to make a query
  - See that it works


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5010
