### PR TITLE
Re-enable ability to query by CVE notes

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -115,6 +115,7 @@ def get_cves(**kwargs):
                 CVE.ubuntu_description.ilike(f"%{query}%"),
                 CVE.codename.ilike(f"%{query}%"),
                 CVE.mitigation.ilike(f"%{query}%"),
+                CVE.notes.ilike(f"%{query}%"),
             )
         )
 


### PR DESCRIPTION
## Done

Re-enable ability to query by CVE notes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5011

## Screenshots

[if relevant, include a screenshot]
