### PR TITLE
Retain functionality for empty status strings

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,9 +56,7 @@ jobs:
         uses: canonical/install-dotrun@main
 
       - name: Install dependencies
-        run: |
-          sudo chmod -R 777 .
-          dotrun install
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Run dotrun
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,10 +53,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Install dependencies
-        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256resolved: https://github.com/docker/docker-py/issues/3256
+        run: |
+          sudo chmod -R 777 .
+          dotrun install
 
       - name: Run dotrun
         run: |

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -129,9 +129,14 @@ def get_cves(**kwargs):
     if component:
         parameters.append(Status.component == component)
 
+    # If an empty string is provided for the status,
+    # retain legacy functionality by ignoring it
     if statuses:
         for status in statuses:
-            parameters.append(Status.status == status)
+            if status == "":
+                continue
+            else:
+                parameters.append(Status.status == status)
 
     if versions:
         for version in versions:


### PR DESCRIPTION
## Done

- Address empty status string error

## Rationale 

 Before https://github.com/canonical/ubuntu-com-security-api/pull/137, version and status filtering had to be done together. For eg, to query for CVEs for jammy you'd need to write the query like so `version="jammy"&status=""`. Now that these have been decoupled the same functionality is achieved with just `version="jammy"`. This has already been refactored on the CVE overhaul branch, but the current CVE table form on u.com still uses the original querying functionality so this PR ensures there will be no errors while we finish the overhaul story.  

## QA

- See that test are passing

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11570