### PR TITLE
Improve notices endpoint

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -448,6 +448,7 @@ def get_notices(**kwargs):
             )
         )
         .options(selectinload(Notice.releases))
+        .order_by(Notice.published, Notice.id)
         .offset(offset)
         .limit(limit)
         .all()

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -451,7 +451,6 @@ def get_notices(**kwargs):
             )
         )
         .options(selectinload(Notice.releases))
-        .order_by(sort(Notice.published), sort(Notice.id))
         .offset(offset)
         .limit(limit)
         .all()

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -412,7 +412,6 @@ def get_notices(**kwargs):
     release = kwargs.get("release")
     limit = kwargs.get("limit", 20)
     offset = kwargs.get("offset", 0)
-    order_by = kwargs.get("order")
 
     notices_query: Query = db.session.query(Notice)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -437,8 +437,6 @@ def get_notices(**kwargs):
             )
         )
 
-    sort = asc if order_by == "oldest" else desc
-
     notices = (
         notices_query.options(
             selectinload(Notice.cves).options(


### PR DESCRIPTION
## Done

Querying notices takes quite a while to complete, ~15s on average. This PR hopes to improve the db query by reworking how the notice json is built.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Open /security/cves.json and /security/notices.json
- Check that they both return in reasonable time

## Notes
- You'll need a database with a significant number of records to replicate the issue (~9000 notices, ~240000 cves)
