### PR TITLE
Gunicorn: Use sync workers instead of gevent

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -17,5 +17,5 @@ FLASK_APP=webapp.app flask db upgrade
 
 # Start server
 # ===
-talisker.gunicorn.gevent webapp.app:app --bind $1 --workers 2 --worker-class gevent --name talisker-`hostname` ${DEBUG_ARGS}
+talisker.gunicorn webapp.app:app --bind $1 --workers 2 --name talisker-`hostname` ${DEBUG_ARGS}
 


### PR DESCRIPTION
## Done

Remove gevent, which will hopefully help us have a more accurate picture on the number of DB connections.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Make sure the site runs
