### PR TITLE
Add fuzzy search for packages

### DIFF
--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -9,9 +9,9 @@ cve1 = {
     "codename": "testcodename",
     "packages": [
         {
-            "debian": "https://tracker.debian.org/pkg/test_package_1",
-            "name": "test_package_1",
-            "source": "https://ubuntu.com/security/cve?package=test_package_1",
+            "debian": "https://tracker.debian.org/pkg/mysql",
+            "name": "mysql",
+            "source": "https://ubuntu.com/security/cve?package=mysql",
             "statuses": [
                 {
                     "description": "",
@@ -22,7 +22,7 @@ cve1 = {
             ],
             "ubuntu": (
                 "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-                "=any&searchon=sourcenames&keywords=test_package_1"
+                "=any&searchon=sourcenames&keywords=mysql"
             ),
         }
     ],
@@ -55,9 +55,9 @@ cve2 = {
     "codename": "testcodename2",
     "packages": [
         {
-            "debian": "https://tracker.debian.org/pkg/test_package_2",
-            "name": "test_package_2",
-            "source": "https://ubuntu.com/security/cve?package=test_package21",
+            "debian": "https://tracker.debian.org/pkg/mysql",
+            "name": "mysql-8.0",
+            "source": "https://ubuntu.com/security/cve?package=mysql-8.0",
             "statuses": [
                 {
                     "description": "",
@@ -67,7 +67,7 @@ cve2 = {
             ],
             "ubuntu": (
                 "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-                "=any&searchon=sourcenames&keywords=test_package_2"
+                "=any&searchon=sourcenames&keywords=mysql"
             ),
         }
     ],
@@ -81,9 +81,9 @@ cve3 = {
     "codename": "testcodename3",
     "packages": [
         {
-            "debian": "https://tracker.debian.org/pkg/test_package_3",
-            "name": "test_package_3",
-            "source": "https://ubuntu.com/security/cve?package=test_package_3",
+            "debian": "https://tracker.debian.org/pkg/postgresql-14",
+            "name": "postgresql-14",
+            "source": "https://ubuntu.com/security/cve?package=postgresql-14",
             "statuses": [
                 {
                     "description": "",
@@ -93,7 +93,7 @@ cve3 = {
             ],
             "ubuntu": (
                 "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-                "=any&searchon=sourcenames&keywords=test_package_3"
+                "=any&searchon=sourcenames&keywords=postgresql-14"
             ),
         }
     ],
@@ -107,9 +107,9 @@ cve4 = {
     "codename": "testcodename4",
     "packages": [
         {
-            "debian": "https://tracker.debian.org/pkg/test_package_4",
+            "debian": "https://tracker.debian.org/pkg/postgresql",
             "name": "test_package_3",
-            "source": "https://ubuntu.com/security/cve?package=test_package_4",
+            "source": "https://ubuntu.com/security/cve?package=postgresql",
             "statuses": [
                 {
                     "description": "",
@@ -119,7 +119,7 @@ cve4 = {
             ],
             "ubuntu": (
                 "https://packages.ubuntu.com/search?suite=all&section=all&arch"
-                "=any&searchon=sourcenames&keywords=test_package_4"
+                "=any&searchon=sourcenames&keywords=postgresql"
             ),
         }
     ],

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -493,11 +493,11 @@ class TestRoutes(unittest.TestCase):
         assert add_cves_response.status_code == 200
 
         filtered_cves_response = self.client.get(
-            "/security/cves.json?package=test_package_2&version=testrelease"
+            "/security/cves.json?package=sql&version=testrelease"
         )
 
         assert filtered_cves_response.status_code == 200
-        assert filtered_cves_response.json["total_results"] == 1
+        assert filtered_cves_response.json["total_results"] == 2
 
     def test_cves_filtered_by_package_and_status(self):
         # Add releases because the DB only includes
@@ -534,7 +534,7 @@ class TestRoutes(unittest.TestCase):
         assert add_cves_response.status_code == 200
 
         filtered_cves_response = self.client.get(
-            "/security/cves.json?package=test_package_2&status=released"
+            "/security/cves.json?package=mysql&status=released"
         )
 
         assert filtered_cves_response.status_code == 200

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -149,7 +149,7 @@ def get_cves(**kwargs):
 
         # filter by package name
         if package:
-            parameters.append(Status.package_name == package)
+            parameters.append(Status.package_name.ilike(f"%{package}%"))
 
         # filter by component
         if component:
@@ -165,7 +165,7 @@ def get_cves(**kwargs):
                     CVE.statuses.any(or_(*[p for p in parameters]))
                 )
 
-    # filter the CVE statuses that fulfil creatia
+    # filter the CVE statuses that fulfills criteria
     cve_statuses_query = cve_statuses_query.and_(*[p for p in parameters])
 
     cve_notices_query = CVE.notices


### PR DESCRIPTION
## Done

Add fuzzy search for packages:
"mysql-8.0" returns an expected result for Ubuntu 22.04 LTS.
https://ubuntu.com/security/cves?q=&package=mysql-8.0

However, "mysql" doesn't contains expected result for Ubuntu 22.04 LTS.
https://ubuntu.com/security/cves?q=&package=mysql

The same condition applies to PostgreSQL.

"postgresql-14" works.
https://ubuntu.com/security/cves?q=&package=postgresql-14

However, "postgresql" doesn't contains expected result:
https://ubuntu.com/security/cves?q=&package=postgresql

- Update tests to cover for these cases.

## QA

- Check out this feature branch 
- Run the site using the command `./run serve
- http://0.0.0.0:8030/security/cves.json?package=sql should return results . You can try current prod http://ubuntu.com/security/cves.json?package=sql which doesn't return any
- Tests should pass


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4755

