### PR TITLE
Reduce fields returned by notice cves

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -944,6 +944,17 @@ class TestRoutes(unittest.TestCase):
         assert response.status_code == 200
         assert response.json["cves_ids"] == self.models["notice"].cves_ids
 
+    def test_usn_with_reduced_cves(self):
+        response = self.client.get("/security/notices.json?reduce_cves=True")
+
+        assert response.status_code == 200
+        # There should only be two fields
+
+        assert response.json["notices"][0]["cves"][0].keys() == {
+            "id",
+            "published",
+        }
+
     def test_usn_with_multiple_cves(self):
         # Create additional cves
         response_3 = self.client.put(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -944,6 +944,27 @@ class TestRoutes(unittest.TestCase):
         assert response.status_code == 200
         assert response.json["cves_ids"] == self.models["notice"].cves_ids
 
+    def test_usn_with_detail_filter(self):
+        # We get an incomplete notice_id
+        notice_id = self.models["notice"].id[1:-1]
+        response = self.client.get(
+            f"/security/notices.json?details={notice_id}"
+        )
+
+        assert response.status_code == 200
+        assert response.json["notices"][0]["id"] == self.models["notice"].id
+
+    def test_usn_with_cve_id_filter(self):
+        response = self.client.get(
+            f"/security/notices.json?cve_id={self.models['cve'].id}"
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.json["notices"][0]["cves"][0]["id"]
+            == self.models["cve"].id
+        )
+
     def test_usn_with_reduced_cves(self):
         response = self.client.get("/security/notices.json?reduce_cves=True")
 

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -289,6 +289,13 @@ NoticesParameters = {
         ),
         allow_none=True,
     ),
+    "reduce_cves": Boolean(
+        description=(
+            "True or False if you want full bodied cves or just the ids."
+            "Default is False."
+        ),
+        allow_none=True,
+    ),
 }
 
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -654,13 +654,13 @@ def _get_cves_for_notice(notice):
     else:
         # Create a query list using the first result
         cves_list = (
-            db.session.query(CVE).filter(CVE.id == result_set[0][1]).all()
+            db.session.query(CVE.id, CVE.published).filter(CVE.id == result_set[0][1]).all()
         )
 
         # Then populate the list with the rest of the results
         for i in result_set[1:]:
             cves_list.append(
-                db.session.query(CVE).filter(CVE.id == i[1]).one()
+                db.session.query(CVE.id).filter(CVE.id == i[1]).one()
             )
 
         notice.cves = cves_list

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -654,7 +654,9 @@ def _get_cves_for_notice(notice):
     else:
         # Create a query list using the first result
         cves_list = (
-            db.session.query(CVE.id, CVE.published).filter(CVE.id == result_set[0][1]).all()
+            db.session.query(CVE.id, CVE.published)
+            .filter(CVE.id == result_set[0][1])
+            .all()
         )
 
         # Then populate the list with the rest of the results
@@ -664,9 +666,6 @@ def _get_cves_for_notice(notice):
             )
 
         notice.cves = cves_list
-
-    if not result_set:
-        notice.cves = []
 
     return notice
 


### PR DESCRIPTION
## Done

- Created an optional parameter `reduce_cves` to reduce the number of CVE fields returned on notices.cves
- The rationale here is to reduce the size of the notices.json payload which can be over 250MB

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)


