### PR TITLE
Include notes in the CVEs text field search

### DIFF
--- a/scripts/generate-sample-security-data.py
+++ b/scripts/generate-sample-security-data.py
@@ -41,7 +41,7 @@ with app.app_context():
                 published=datetime.now(),
                 description="",
                 ubuntu_description="",
-                notes={},
+                notes=[],
                 priority="unknown",
                 cvss3=2.3,
                 mitigation="",

--- a/scripts/payloads/cves.json
+++ b/scripts/payloads/cves.json
@@ -27,7 +27,6 @@
                 "impactScore": 5.9
             }
         },
-        "notes": [],
         "packages": [
             {
                 "debian": "https://tracker.debian.org/pkg/chromium-browser",

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -28,7 +28,12 @@ def make_models():
         published=datetime.now(),
         description="",
         ubuntu_description="",
-        notes={},
+        notes=[
+            {
+                "author": "mysql",
+                "note": "mysql-1.2 is not affected by this CVE",
+            }
+        ],
         priority="critical",
         cvss3=2.3,
         impact={},

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1083,6 +1083,18 @@ class TestRoutes(unittest.TestCase):
         )
         assert response.status_code == 200
 
+    def test_cves_query_notes(self):
+        """
+        Query text field should include notes
+        """
+        # Act
+        response = self.client.get("/security/cves.json?q=sql")
+
+        # Assert
+        assert response.status_code == 200
+        assert response.json["total_results"] == 1
+        assert len(response.json["cves"]) == 1
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -57,7 +57,7 @@ class CVE(db.Model):
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
-    notes = Column(JSON)
+    notes = Column(JSON)  # JSON array
     codename = Column(String)
     priority = Column(
         Enum(


### PR DESCRIPTION
## Done

Allow notes to be searchable with the text field. This is an OR type of search.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/cves.json?q=sql should show results from the notes section.
- Ideally test with prod data
- Tests should pass


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11712

