### PR TITLE
Created endpoint for serving upsert requests

### DIFF
--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -1,0 +1,85 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ubuntu-com-security-api-updates
+spec:
+  selector:
+    app: ubuntu-com-security-api-updates
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ubuntu-com-security-api-updates
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ubuntu-com-security-api-updates
+  template:
+    metadata:
+      labels:
+        app: ubuntu-com-security-api-updates
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - ubuntu-com-security-api-updates
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: ubuntu-com-security-api-updates
+          image: prod-comms.ps5.docker-registry.canonical.com/ubuntu-com-security-api-updates:${TAG_TO_DEPLOY}
+
+          ports:
+            - name: http
+              containerPort: 80
+
+          env:
+            - name: TALISKER_NETWORKS
+              value: 10.0.0.0/8
+
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: ubuntu-com-security-api-updates
+                  name: secret-keys
+
+            - name: HTTP_PROXY
+              value: "http://squid.internal:3128/"
+
+            - name: HTTPS_PROXY
+              value: "http://squid.internal:3128/"
+
+            - name: NO_PROXY
+              value: ".internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io"
+
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: database_url
+                  name: usn-db-url
+
+            - name: SENTRY_DSN
+              value: "https://1e974d641a14437e9573e8fe9958a252@sentry.is.canonical.com//48"
+
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            periodSeconds: 5
+            timeoutSeconds: 3
+
+          resources:
+            limits:
+              memory: 512Mi

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1067,7 +1067,9 @@ class TestRoutes(unittest.TestCase):
         notice = payloads.notice.copy()
         notice["unknown"] = "field"
 
-        response = self.client.post("/security/updates/notices.json", json=notice)
+        response = self.client.post(
+            "/security/updates/notices.json", json=notice
+        )
 
         assert response.status_code == 422
         assert "Unknown field." in response.json["errors"]
@@ -1077,7 +1079,9 @@ class TestRoutes(unittest.TestCase):
 
         # Create first
         notice = payloads.notice.copy()
-        response_1 = self.client.post("/security/updates/notices.json", json=notice)
+        response_1 = self.client.post(
+            "/security/updates/notices.json", json=notice
+        )
         assert response_1.status_code == 200
 
         # Update
@@ -1155,7 +1159,9 @@ class TestRoutes(unittest.TestCase):
         ) in response_2.json["errors"]
 
     def test_delete_non_existing_release_returns_404(self):
-        response = self.client.delete("/security/updates/releases/no-exist.json")
+        response = self.client.delete(
+            "/security/updates/releases/no-exist.json"
+        )
 
         assert response.status_code == 404
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -144,13 +144,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only
         # includes 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -160,7 +160,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -184,7 +184,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -208,13 +208,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -224,7 +224,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -249,13 +249,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -265,7 +265,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -290,13 +290,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -306,7 +306,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -330,13 +330,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -346,7 +346,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -371,13 +371,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -387,7 +387,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -412,13 +412,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -428,7 +428,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -453,13 +453,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -469,7 +469,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -494,13 +494,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -510,7 +510,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -535,13 +535,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -551,7 +551,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -678,7 +678,7 @@ class TestRoutes(unittest.TestCase):
         cve_payload = payloads.cve1.copy()
 
         add_cve_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[cve_payload],
         )
 
@@ -691,7 +691,7 @@ class TestRoutes(unittest.TestCase):
 
         # Pass an update to the CVE
         update_cve_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[{"id": "CVE-9999-0001", "codename": "new_codename"}],
         )
 
@@ -714,7 +714,7 @@ class TestRoutes(unittest.TestCase):
         cve_payload = payloads.cve1.copy()
 
         add_cve_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[cve_payload],
         )
 
@@ -724,7 +724,7 @@ class TestRoutes(unittest.TestCase):
 
         # Pass an update to the CVE
         update_cve_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[cve_payload],
         )
 
@@ -748,7 +748,7 @@ class TestRoutes(unittest.TestCase):
         cve_payload = payloads.cve1.copy()
 
         add_cve_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[cve_payload],
         )
 
@@ -756,7 +756,7 @@ class TestRoutes(unittest.TestCase):
 
         # Try to update updated_at field
         update_cve_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[{"updated_at": "2023-03-26T13:59:23.966558+00:00"}],
         )
 
@@ -777,13 +777,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -793,7 +793,7 @@ class TestRoutes(unittest.TestCase):
         # Add CVEs of varying priority, including one without
         # a status field (cve1)
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve1,
                 payloads.cve2,
@@ -849,21 +849,21 @@ class TestRoutes(unittest.TestCase):
 
         # Add CVEs at different intervals to create separate publish dates
         add_cves_response1 = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
             ],
         )
 
         add_cves_response2 = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve3,
             ],
         )
 
         add_cves_response3 = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve4,
             ],
@@ -913,17 +913,17 @@ class TestRoutes(unittest.TestCase):
         payloads.cve4["codename"] = "new_name4"
 
         update_cves_response1 = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[payloads.cve2],
         )
 
         update_cves_response2 = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[payloads.cve3],
         )
 
         update_cves_response3 = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[payloads.cve4],
         )
 
@@ -963,7 +963,7 @@ class TestRoutes(unittest.TestCase):
         cve = payloads.cve1.copy()
         cve["hello"] = "world"
 
-        response = self.client.put("/security/cves.json", json=[cve])
+        response = self.client.put("/security/updates/cves.json", json=[cve])
 
         assert response.status_code == 422
         assert "Unknown field." in response.json["errors"]
@@ -980,7 +980,7 @@ class TestRoutes(unittest.TestCase):
         assert response_2.status_code == 404
 
         response_3 = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve1,
                 payloads.cve2,
@@ -1000,14 +1000,14 @@ class TestRoutes(unittest.TestCase):
 
     def test_delete_non_existing_cve_returns_404(self):
         response = self.client.delete(
-            f"/security/cves/{payloads.cve1['id']}.json"
+            f"/security/updates/cves/{payloads.cve1['id']}.json"
         )
 
         assert response.status_code == 404
 
     def test_delete_cve(self):
         response = self.client.delete(
-            f"/security/cves/{self.models['cve'].id}.json"
+            f"/security/updates/cves/{self.models['cve'].id}.json"
         )
         assert response.status_code == 200
 
@@ -1034,14 +1034,14 @@ class TestRoutes(unittest.TestCase):
 
     def test_create_usn(self):
         response = self.client.post(
-            "/security/notices.json", json=payloads.notice
+            "/security/updates/notices.json", json=payloads.notice
         )
 
         assert response.status_code == 200
 
     def test_create_ssn_usn(self):
         response = self.client.post(
-            "/security/notices.json", json=payloads.ssn_notice
+            "/security/updates/notices.json", json=payloads.ssn_notice
         )
 
         assert response.status_code == 200
@@ -1049,13 +1049,13 @@ class TestRoutes(unittest.TestCase):
     def test_create_usn_returns_422_for_non_unique_id(self):
         # Create USN
         response_1 = self.client.post(
-            "/security/notices.json", json=payloads.notice
+            "/security/updates/notices.json", json=payloads.notice
         )
         assert response_1.status_code == 200
 
         # Create again
         response_2 = self.client.post(
-            "/security/notices.json", json=payloads.notice
+            "/security/updates/notices.json", json=payloads.notice
         )
         assert response_2.status_code == 422
         assert (
@@ -1067,7 +1067,7 @@ class TestRoutes(unittest.TestCase):
         notice = payloads.notice.copy()
         notice["unknown"] = "field"
 
-        response = self.client.post("/security/notices.json", json=notice)
+        response = self.client.post("/security/updates/notices.json", json=notice)
 
         assert response.status_code == 422
         assert "Unknown field." in response.json["errors"]
@@ -1077,13 +1077,13 @@ class TestRoutes(unittest.TestCase):
 
         # Create first
         notice = payloads.notice.copy()
-        response_1 = self.client.post("/security/notices.json", json=notice)
+        response_1 = self.client.post("/security/updates/notices.json", json=notice)
         assert response_1.status_code == 200
 
         # Update
         notice["instructions"] = instructions
         response_2 = self.client.put(
-            f"/security/notices/{notice['id']}.json", json=notice
+            f"/security/updates/notices/{notice['id']}.json", json=notice
         )
         assert response_2.status_code == 200
 
@@ -1093,7 +1093,7 @@ class TestRoutes(unittest.TestCase):
 
     def test_update_usn_returns_404_for_non_existing_id(self):
         response = self.client.put(
-            f"/security/notices/{payloads.notice['id']}.json",
+            f"/security/updates/notices/{payloads.notice['id']}.json",
             json=payloads.notice,
         )
 
@@ -1104,7 +1104,7 @@ class TestRoutes(unittest.TestCase):
         notice["unknown"] = "field"
 
         response = self.client.put(
-            f"/security/notices/{notice['id']}.json", json=notice
+            f"/security/updates/notices/{notice['id']}.json", json=notice
         )
 
         assert response.status_code == 422
@@ -1112,7 +1112,7 @@ class TestRoutes(unittest.TestCase):
 
     def test_delete_usn_returns_404_for_non_existing_usn(self):
         response = self.client.delete(
-            f"/security/notices/{payloads.notice['id']}.json"
+            f"/security/updates/notices/{payloads.notice['id']}.json"
         )
 
         assert response.status_code == 404
@@ -1120,19 +1120,19 @@ class TestRoutes(unittest.TestCase):
     def test_delete_usn(self):
         # Create USN first
         response = self.client.post(
-            "/security/notices.json", json=payloads.notice
+            "/security/updates/notices.json", json=payloads.notice
         )
         assert response.status_code == 200
 
         # Now delete it
         response = self.client.delete(
-            f"/security/notices/{payloads.notice['id']}.json"
+            f"/security/updates/notices/{payloads.notice['id']}.json"
         )
         assert response.status_code == 200
 
     def test_create_release(self):
         response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
 
         assert response.status_code == 200
@@ -1140,13 +1140,13 @@ class TestRoutes(unittest.TestCase):
     def test_create_existing_release_returns_422(self):
         # Create release
         response_1 = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         assert response_1.status_code == 200
 
         # Create release again
         response_2 = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         assert response_2.status_code == 422
         assert (
@@ -1155,20 +1155,20 @@ class TestRoutes(unittest.TestCase):
         ) in response_2.json["errors"]
 
     def test_delete_non_existing_release_returns_404(self):
-        response = self.client.delete("/security/releases/no-exist.json")
+        response = self.client.delete("/security/updates/releases/no-exist.json")
 
         assert response.status_code == 404
 
     def test_delete_release(self):
         # Create release first
         response_1 = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         assert response_1.status_code == 200
 
         # Delete release
         response = self.client.delete(
-            f"/security/releases/{payloads.release['codename']}.json"
+            f"/security/updates/releases/{payloads.release['codename']}.json"
         )
         assert response.status_code == 200
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -577,13 +577,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -593,7 +593,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,
@@ -618,13 +618,13 @@ class TestRoutes(unittest.TestCase):
         # Add releases because the DB only includes
         # 1 release upon initialization
         add_release_response = self.client.post(
-            "/security/releases.json", json=payloads.release
+            "/security/updates/releases.json", json=payloads.release
         )
         add_release2_response = self.client.post(
-            "/security/releases.json", json=payloads.release2
+            "/security/updates/releases.json", json=payloads.release2
         )
         add_release3_response = self.client.post(
-            "/security/releases.json", json=payloads.release3
+            "/security/updates/releases.json", json=payloads.release3
         )
 
         assert add_release_response.status_code == 200
@@ -634,7 +634,7 @@ class TestRoutes(unittest.TestCase):
         # Add cves with different statuses because the
         # DB only includes 1 cve upon initialization
         add_cves_response = self.client.put(
-            "/security/cves.json",
+            "/security/updates/cves.json",
             json=[
                 payloads.cve2,
                 payloads.cve3,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -62,20 +62,6 @@ app.add_url_rule(
 )
 
 app.add_url_rule(
-    "/security/cves.json",
-    view_func=bulk_upsert_cve,
-    methods=["PUT"],
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
-    "/security/cves/<cve_id>.json",
-    view_func=delete_cve,
-    methods=["DELETE"],
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
     "/security/notices/<notice_id>.json",
     view_func=get_notice,
     provide_automatic_options=False,
@@ -84,27 +70,6 @@ app.add_url_rule(
 app.add_url_rule(
     "/security/notices.json",
     view_func=get_notices,
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
-    "/security/notices.json",
-    view_func=create_notice,
-    methods=["POST"],
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
-    "/security/notices/<notice_id>.json",
-    view_func=update_notice,
-    methods=["PUT"],
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
-    "/security/notices/<notice_id>.json",
-    view_func=delete_notice,
-    methods=["DELETE"],
     provide_automatic_options=False,
 )
 
@@ -120,20 +85,59 @@ app.add_url_rule(
     methods=["GET"],
     provide_automatic_options=False,
 )
+
+# Upsert endpoints are declared on /security/updates for performance reasons
+
 app.add_url_rule(
-    "/security/releases.json",
+    "/security/updates/cves.json",
+    view_func=bulk_upsert_cve,
+    methods=["PUT"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/updates/cves/<cve_id>.json",
+    view_func=delete_cve,
+    methods=["DELETE"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/updates/notices.json",
+    view_func=create_notice,
+    methods=["POST"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/updates/notices/<notice_id>.json",
+    view_func=update_notice,
+    methods=["PUT"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/updates/notices/<notice_id>.json",
+    view_func=delete_notice,
+    methods=["DELETE"],
+    provide_automatic_options=False,
+)
+
+
+app.add_url_rule(
+    "/security/updates/releases.json",
     view_func=create_release,
     methods=["POST"],
     provide_automatic_options=False,
 )
 app.add_url_rule(
-    "/security/releases/<release_codename>.json",
+    "/security/updates/releases/<release_codename>.json",
     view_func=update_release,
     methods=["PUT"],
     provide_automatic_options=False,
 )
 app.add_url_rule(
-    "/security/releases/<release_codename>.json",
+    "/security/updates/releases/<release_codename>.json",
     view_func=delete_release,
     methods=["DELETE"],
     provide_automatic_options=False,


### PR DESCRIPTION
## Done

- Put all upsert requests behind `/security/updates/`
- The rationale here is that we don't want the security team to be blocked by intermittent resource-related issues on the main `/security` endpoint.
- This PR by itself doesn't create the deployment, but sets it up. The following also need to be implemented
- [x] Update [Jenkins](https://jenkins.canonical.com/webteam/job/ubuntu-com-security-api/configure) to deploy a new service for this endpoint
- [ ] Merge [this PR](https://github.com/canonical/ubuntu.com/pull/13999) to update the u.com ingress to direct `/security/updates` traffic to the new service (staging only)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Test insertions

