### PR TITLE
Created endpoint with smaller notices

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1024,6 +1024,27 @@ class TestRoutes(unittest.TestCase):
         assert response.status_code == 200
         assert response.json["cves_ids"] == self.models["notice"].cves_ids
 
+    def test_multiple_usn(self):
+        response = self.client.get("/security/notices.json")
+
+        assert response.status_code == 200
+        # Should include cve
+        assert (
+            self.models["notice"].id
+            in response.json["notices"][0]["cves"][0]["notices_ids"]
+        )
+
+    def test_page_notice(self):
+        response = self.client.get("/security/page/notices.json")
+
+        assert response.status_code == 200
+        assert (
+            response.json["notices"][0]["cves_ids"]
+            == self.models["notice"].cves_ids
+        )
+        # Should not include cves
+        assert response.json["notices"][0].get("cves") is None
+
     def test_usns_returns_200_for_non_existing_release(self):
         response = self.client.get("/security/notices.json?release=no-exist")
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1045,6 +1045,42 @@ class TestRoutes(unittest.TestCase):
         # Should not include cves
         assert response.json["notices"][0].get("cves") is None
 
+        # Test details field
+        response = self.client.get(
+            (
+                "/security/page/notices.json?"
+                f"details={self.models['notice'].id[:3]}"
+            )
+        )
+
+        assert response.status_code == 200
+        assert response.json["notices"][0]["id"] == self.models["notice"].id
+
+        # Test cve_id field
+        response = self.client.get(
+            (
+                "/security/page/notices.json"
+                f"?cve_id={self.models['notice'].cves[0].id}"
+            )
+        )
+
+        assert response.status_code == 200
+        assert response.json["notices"][0]["id"] == self.models["notice"].id
+
+        # Test release field
+        response = self.client.get(
+            (
+                "/security/page/notices.json?"
+                f"release={self.models['notice'].releases[0].codename}"
+            )
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.json["notices"][0]["releases"][0]["codename"]
+            == self.models["notice"].releases[0].codename
+        )
+
     def test_usns_returns_200_for_non_existing_release(self):
         response = self.client.get("/security/notices.json?release=no-exist")
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9,20 +9,21 @@ from flask_migrate import Migrate
 from webapp.api_spec import WebappFlaskApiSpec
 from webapp.database import db
 from webapp.views import (
-    get_cve,
-    get_notice,
-    get_cves,
-    get_notices,
     create_notice,
-    update_notice,
-    delete_notice,
+    create_release,
     delete_cve,
     bulk_upsert_cve,
-    create_release,
+    delete_notice,
     delete_release,
-    update_release,
+    get_cve,
+    get_cves,
+    get_notice,
+    get_notices,
+    get_page_notices,
     get_release,
     get_releases,
+    update_notice,
+    update_release,
 )
 
 
@@ -70,6 +71,33 @@ app.add_url_rule(
 app.add_url_rule(
     "/security/notices.json",
     view_func=get_notices,
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/page/notices.json",
+    view_func=get_page_notices,
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/notices.json",
+    view_func=create_notice,
+    methods=["POST"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/notices/<notice_id>.json",
+    view_func=update_notice,
+    methods=["PUT"],
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/notices/<notice_id>.json",
+    view_func=delete_notice,
+    methods=["DELETE"],
     provide_automatic_options=False,
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -81,32 +81,12 @@ app.add_url_rule(
 )
 
 app.add_url_rule(
-    "/security/notices.json",
-    view_func=create_notice,
-    methods=["POST"],
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
-    "/security/notices/<notice_id>.json",
-    view_func=update_notice,
-    methods=["PUT"],
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
-    "/security/notices/<notice_id>.json",
-    view_func=delete_notice,
-    methods=["DELETE"],
-    provide_automatic_options=False,
-)
-
-app.add_url_rule(
     "/security/releases/<release_codename>.json",
     view_func=get_release,
     methods=["GET"],
     provide_automatic_options=False,
 )
+
 app.add_url_rule(
     "/security/releases.json",
     view_func=get_releases,

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -427,6 +427,19 @@ class NoticeAPIDetailedSchema(NoticeAPISchema):
     releases = List(Nested(NoticeReleasesSchema))
 
 
+class PageNoticeAPISchema(NoticeSchema):
+    cves_ids = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
+    notice_type = String(data_key="type")
+    releases = List(Nested(NoticeReleasesSchema))
+
+
+class PageNoticesAPISchema(Schema):
+    notices = List(Nested(PageNoticeAPISchema))
+    offset = Int(allow_none=True)
+    limit = Int(allow_none=True)
+    total_results = Int()
+
+
 class CVEAPIDetailedSchema(CVEAPISchema):
     notices = List(Nested(NoticeAPISchema))
 


### PR DESCRIPTION
## Done

- Created a new endpoint at `/security/page/notices.json`
  - serves notices without the `cves` or `packages` fields.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Access the new endpoint at http://0.0.0.0:8030/security/page/notices.json
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes [WD-12682](https://warthogs.atlassian.net/browse/WD-12682?atlOrigin=eyJpIjoiNzY3ZGNiMzI5YjcyNDA0MmFlMzU2NTJjMmZjODA0ZjAiLCJwIjoiaiJ9)


[WD-12682]: https://warthogs.atlassian.net/browse/WD-12682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ