### PR TITLE
Add get_page_notices to swagger

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -157,6 +157,7 @@ views_to_register_in_docs = [
     bulk_upsert_cve,
     delete_cve,
     get_notice,
+    get_page_notices,
     get_notices,
     create_notice,
     update_notice,


### PR DESCRIPTION
## Done

- Added get_page_notices to swagger

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/api/docs
- Check that `/security/page/notices/` is included 

Fixes #
- `/security/page/notices/` not included in swagger docs