### PR TITLE
Limit notices requests to 20 at most

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -946,6 +946,10 @@ class TestRoutes(BaseTestCase):
         assert response.status_code == 200
         assert response.json["cves_ids"] == self.models["notice"].cves_ids
 
+        # Test request limit
+        response = self.client.get("/security/notices.json?limit=21")
+        assert response.status_code == 422
+
         # Test cves field
         cve_id = self.models["notice"].cves[0].id
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -427,6 +427,12 @@ def get_notices(**kwargs):
     order_by = kwargs.get("order")
     cves = kwargs.get("cves")
 
+    # Restrict limit to 20 notices at a time
+    if limit > 20:
+        return make_response(
+            jsonify({"message": "Limit cannot exceed 20"}), 422
+        )
+
     notices_query: Query = db.session.query(Notice)
 
     if not kwargs.get("show_hidden", False):


### PR DESCRIPTION
## Done

- Added a hard limit to how many notices can be requested.
- This is to reduce the pressure on the backend to assemble and serve very large json payloads.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- Request more than 20 notices e.g.
- `/security/notices.json?limit=21` 
- - Request fewer than 20 notices e.g.
- `/security/notices.json?limit=19`
