### PR TITLE
add default sort on /cves

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -192,6 +192,8 @@ def get_cves(**kwargs):
         sort = asc
     elif order == "descending":
         sort = desc
+    else:
+        sort = desc
 
     if sort_by == "published":
         sort_field = CVE.published


### PR DESCRIPTION
## Done

- Fixes undefined sort value when an invalid value for query param `order` is provided

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/cves.json\?order\=invalid
- Make sure that the endpoints works as expected without failing


## Issue / Card

Fixes [WD-13877](https://warthogs.atlassian.net/browse/WD-13877)


[WD-13877]: https://warthogs.atlassian.net/browse/WD-13877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ