### PR TITLE
temporarily increase security-api service memory limit

### DIFF
--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -82,4 +82,4 @@ spec:
 
           resources:
             limits:
-              memory: 1G
+              memory: 2G


### PR DESCRIPTION
## Done

- Increase the memory limit for `ubuntu-com-security-api`
