### PR TITLE
Improve security notices endpoint

### DIFF
--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -8,13 +8,11 @@ from marshmallow.fields import (
     List,
     Nested,
     String,
-    Enum,
     Int,
 )
 from marshmallow.validate import Regexp, Range
 
 from webapp.models import Package, Notice, Release, STATUS_STATUSES
-import enum
 
 # Types
 COMPONENT_OPTIONS = ["main", "universe"]
@@ -287,17 +285,20 @@ NoticesParameters = {
         allow_none=True,
     ),
     "release": String(
-        description='Ubuntu release codename to filter notices by, e.g. `"noble"`.',
+        description="Ubuntu release codename to filter notices by."
+        'example: `"noble"`.',
         allow_none=True,
     ),
     "limit": Int(
         validate=Range(min=1, max=20),
-        description="Number of Notices per response. Defaults to `20`. Max `20`.",
+        description="Number of Notices per response."
+        "Defaults to `20`. Max `20`.",
         allow_none=True,
         load_default=20,
     ),
     "offset": Int(
-        description="Number of Notices to omit from response. Defaults to `0`.",
+        description="Number of Notices to omit from response."
+        "Defaults to `0`.",
         allow_none=True,
         load_default=0,
     ),

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -8,12 +8,13 @@ from marshmallow.fields import (
     List,
     Nested,
     String,
+    Enum,
     Int,
 )
 from marshmallow.validate import Regexp, Range
 
 from webapp.models import Package, Notice, Release, STATUS_STATUSES
-
+import enum
 
 # Types
 COMPONENT_OPTIONS = ["main", "universe"]
@@ -264,7 +265,7 @@ NoticeParameters = {
     "show_hidden": Boolean(
         description=(
             "True or False if you want to select hidden notices. "
-            "Default is False."
+            "Default is `false`."
         ),
         allow_none=True,
     ),
@@ -274,35 +275,47 @@ NoticesParameters = {
     "details": String(
         description=(
             "Any string - Selects notices that have either "
-            "id, details or cves.id matching it"
+            "id, details or cves.id matching it."
         ),
         allow_none=True,
     ),
-    "cve_id": String(allow_none=True),
-    "cves": StringDelimitedList(allow_none=True),
-    "release": String(allow_none=True),
-    "limit": Int(
-        validate=Range(min=1, max=100),
-        description="Number of Notices per response. Defaults to 20. Max 100.",
+    "cve_id": String(
+        description="CVE ID to filter notices by.", allow_none=True
+    ),
+    "cves": StringDelimitedList(
+        description="Comma-separated list of CVE IDs to filter notices by.",
         allow_none=True,
+    ),
+    "release": String(
+        description='Ubuntu release codename to filter notices by, e.g. `"noble"`.',
+        allow_none=True,
+    ),
+    "limit": Int(
+        validate=Range(min=1, max=20),
+        description="Number of Notices per response. Defaults to `20`. Max `20`.",
+        allow_none=True,
+        load_default=20,
     ),
     "offset": Int(
-        description="Number of Notices to omit from response. Defaults to 0.",
+        description="Number of Notices to omit from response. Defaults to `0`.",
         allow_none=True,
+        load_default=0,
     ),
     "order": String(
-        enum=["oldest"],
+        validate=lambda x: x in ["oldest", "newest"],
         description=(
             "Select order: choose `oldest` for ASC order; "
-            "leave empty for DESC order"
+            "`newest` for DESC order. Default is `newest`."
         ),
+        load_default="newest",
         allow_none=True,
     ),
     "show_hidden": Boolean(
         description=(
             "True or False if you want to select hidden notices. "
-            "Default is False."
+            "Default is `false`."
         ),
+        load_default=False,
         allow_none=True,
     ),
 }

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -21,4 +21,5 @@ def stream_notices(
         else:
             first = False
         yield json.dumps(notice_schema.dump(notice))
-    yield f'],"offset":{offset},"limit":{limit},"total_results":{total_count}}}'
+    yield "],"
+    yield f'"offset":{offset},"limit":{limit},"total_results":{total_count}}}'

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -1,4 +1,3 @@
-import json
 from typing import Generator
 
 from sqlalchemy.orm import Query
@@ -20,6 +19,6 @@ def stream_notices(
             yield ","
         else:
             first = False
-        yield json.dumps(notice_schema.dump(notice))
+        yield notice_schema.dumps(notice)
     yield "],"
     yield f'"offset":{offset},"limit":{limit},"total_results":{total_count}}}'

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -1,0 +1,24 @@
+import json
+from typing import Generator
+
+from sqlalchemy.orm import Query
+
+from webapp.schemas import NoticeAPIDetailedSchema
+
+
+def stream_notices(
+    notices_query: Query, offset: int, limit: int, total_count: int
+) -> Generator[str, None, None]:
+    """
+    Stream notices as JSON object in chunks with one notice at a time.
+    """
+    notice_schema = NoticeAPIDetailedSchema()
+    yield '{"notices":['
+    first = True
+    for notice in notices_query.offset(offset).limit(limit).yield_per(1):
+        if not first:
+            yield ","
+        else:
+            first = False
+        yield json.dumps(notice_schema.dump(notice))
+    yield f'],"offset":{offset},"limit":{limit},"total_results":{total_count}}}'


### PR DESCRIPTION
## Done

- Improve `/notices` endpoint:
  - Improve query param documentation
  - Improve query param value parsing and typing
  - Improve SQL query building readability
  - Stream the notices list to the client: each notice object is big as it contains relations to cve, release and other models, to avoid loading all notices in memory we get one object at a time from the DB and stream to the user.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Make sure that the endpoint `/security/notices.json` has the same behaviour as before
- On an invalid query param value (e.g. `limit=21`, `order=test`), make sure that the service fails with a readable error message


## Issue / Card

Fixes [WD-13903](https://warthogs.atlassian.net/browse/WD-13903)


[WD-13903]: https://warthogs.atlassian.net/browse/WD-13903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ