### PR TITLE
Expand pocket options to include 'esm-infra-legacy' and 'realtime'

### DIFF
--- a/migrations/versions/645c9424286e_expand_pockets.py
+++ b/migrations/versions/645c9424286e_expand_pockets.py
@@ -1,0 +1,52 @@
+"""empty message
+
+Revision ID: 645c9424286e
+Revises: 5df43dc932dd
+Create Date: 2024-08-27 08:30:26.043013
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '645c9424286e'
+down_revision = '5df43dc932dd'
+branch_labels = None
+depends_on = None
+
+# Enum 'type' for PostgreSQL
+enum_name = 'pockets'
+# Set temporary enum 'type' for PostgreSQL
+tmp_enum_name = 'tmp_' + enum_name
+
+# Options for Enum
+old_options = ('security', 'updates', 'esm-infra', 'esm-apps', 'soss', 'fips', 'fips-updates', 'ros-esm')
+new_options = ('security', "updates", "esm-infra", "esm-infra-legacy", "esm-apps", "fips", "fips-updates", "ros-esm", "soss", "realtime",)
+
+#Create enum fields
+old_type = sa.Enum(*old_options, name=enum_name)
+new_type = sa.Enum(*new_options, name=enum_name)
+
+def upgrade():
+    # Rename current enum type to tmp_
+    op.execute('ALTER TYPE ' + enum_name + ' RENAME TO ' + tmp_enum_name)
+    # Create new enum type in db
+    new_type.create(op.get_bind())
+    # Update column to use new enum type
+    op.execute('ALTER TABLE status ALTER COLUMN pocket TYPE ' + enum_name + ' USING pocket::text::' + enum_name)
+    # Drop old enum type
+    op.execute('DROP TYPE ' + tmp_enum_name)
+
+
+def downgrade():
+    # Instantiate db query
+    status = sa.sql.table('status', sa.Column('pocket', new_type, nullable=False))
+    # Rename enum type to tmp_
+    op.execute('ALTER TYPE ' + enum_name + ' RENAME TO ' + tmp_enum_name)
+    # Create enum type using old values
+    old_type.create(op.get_bind())
+    # Set enum type as type for pocket column
+    op.execute('ALTER TABLE status ALTER COLUMN pocket TYPE ' + enum_name + ' USING pocket::text::' + enum_name)
+    # Drop temp enum type
+    op.execute('DROP TYPE ' + tmp_enum_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,5 @@ webargs==6.1.1
 sortedcontainers==2.4.0
 Flask-SQLAlchemy==2.5.1
 Flask-Migrate==3.1.0
-flask-alchemydumps==0.0.13
 SQLAlchemy-Utils==0.41.1
 

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -63,6 +63,7 @@ cve2 = {
                     "description": "",
                     "release_codename": "testrelease",
                     "status": "released",
+                    "pocket": "realtime",
                 }
             ],
             "ubuntu": (
@@ -89,6 +90,7 @@ cve3 = {
                     "description": "",
                     "release_codename": "testrelease",
                     "status": "released",
+                    "pocket": "esm-infra-legacy",
                 }
             ],
             "ubuntu": (

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -906,6 +906,7 @@ class TestRoutes(BaseTestCase):
             json=[
                 payloads.cve1,
                 payloads.cve2,
+                payloads.cve3,
             ],
         )
         assert response_3.status_code == 200
@@ -920,6 +921,11 @@ class TestRoutes(BaseTestCase):
         )
         assert response.status_code == 200
 
+        response = self.client.get(
+            f"/security/cves/{payloads.cve3['id']}.json"
+        )
+        assert response.status_code == 200
+        
     def test_delete_non_existing_cve_returns_404(self):
         response = self.client.delete(
             f"/security/updates/cves/{payloads.cve1['id']}.json"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -925,7 +925,7 @@ class TestRoutes(BaseTestCase):
             f"/security/cves/{payloads.cve3['id']}.json"
         )
         assert response.status_code == 200
-        
+
     def test_delete_non_existing_cve_returns_404(self):
         response = self.client.delete(
             f"/security/updates/cves/{payloads.cve1['id']}.json"

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -297,11 +297,13 @@ class Status(db.Model):
             "security",
             "updates",
             "esm-infra",
+            "esm-infra-legacy",
             "esm-apps",
             "fips",
             "fips-updates",
             "ros-esm",
             "soss",
+            "realtime",
             name="pockets",
         ),
     )

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -21,11 +21,13 @@ POCKET_OPTIONS = [
     "security",
     "updates",
     "esm-infra",
+    "esm-infra-legacy",
     "esm-apps",
     "soss",
     "fips",
     "fips-updates",
     "ros-esm",
+    "realtime",
 ]
 
 PACKAGE_TYPE_OPTIONS = [


### PR DESCRIPTION
## Done

- Added `esm-infra-legacy` and `realtime` pocket options
- Updated `test_bulk_upsert_cves` and related payloads to test these changes
- Drive by:
  - Removed unmaintained package which we do not seem to be using anywhere 
## QA

- See that tests are passing

## Issue / Card

Fixes https://github.com/canonical/ubuntu-com-security-api/issues/174, https://warthogs.atlassian.net/browse/WD-14323
