### PR TITLE
Set a single source of truth for types

### DIFF
--- a/webapp/models.py
+++ b/webapp/models.py
@@ -19,18 +19,11 @@ from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method
 from sqlalchemy.orm import relationship
 
 from webapp.database import db
-
-
-STATUS_STATUSES = Enum(
-    "released",
-    "DNE",
-    "needed",
-    "not-affected",
-    "deferred",
-    "needs-triage",
-    "ignored",
-    "pending",
-    name="statuses",
+from webapp.types import (
+    STATUS_STATUSES,
+    COMPONENT_OPTIONS,
+    POCKET_OPTIONS,
+    PRIORITY_OPTIONS,
 )
 
 
@@ -62,17 +55,7 @@ class CVE(db.Model):
     )
     notes = Column(JSON)  # JSON array
     codename = Column(String)
-    priority = Column(
-        Enum(
-            "unknown",
-            "negligible",
-            "low",
-            "medium",
-            "high",
-            "critical",
-            name="priorities",
-        )
-    )
+    priority = Column(PRIORITY_OPTIONS)
     cvss3 = Column(Float)
     impact = Column(JSON)
     mitigation = Column(String)
@@ -289,24 +272,8 @@ class Status(db.Model):
     )
     status = Column(STATUS_STATUSES)
     description = Column(String)
-    component = Column(
-        Enum("main", "universe", name="components"),
-    )
-    pocket = Column(
-        Enum(
-            "security",
-            "updates",
-            "esm-infra",
-            "esm-infra-legacy",
-            "esm-apps",
-            "fips",
-            "fips-updates",
-            "ros-esm",
-            "soss",
-            "realtime",
-            name="pockets",
-        ),
-    )
+    component = Column(COMPONENT_OPTIONS)
+    pocket = Column(POCKET_OPTIONS)
 
     cve = relationship("CVE", back_populates="statuses")
     package = relationship("Package", back_populates="statuses")

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -12,41 +12,14 @@ from marshmallow.fields import (
 )
 from marshmallow.validate import Regexp, Range
 
-from webapp.models import Package, Notice, Release, STATUS_STATUSES
-
-# Types
-COMPONENT_OPTIONS = ["main", "universe"]
-
-POCKET_OPTIONS = [
-    "security",
-    "updates",
-    "esm-infra",
-    "esm-infra-legacy",
-    "esm-apps",
-    "soss",
-    "fips",
-    "fips-updates",
-    "ros-esm",
-    "realtime",
-]
-
-PACKAGE_TYPE_OPTIONS = [
-    "python",
-    "conda",
-    "golang",
-    "unpackaged",
-    "deb",
-]
-
-PRIORITY_OPTIONS = [
-    "unknown",
-    "negligible",
-    "low",
-    "medium",
-    "high",
-    "critical",
-]
-# ===
+from webapp.models import Package, Notice, Release
+from webapp.types import (
+    STATUS_STATUSES,
+    COMPONENT_OPTIONS,
+    POCKET_OPTIONS,
+    PACKAGE_TYPE_OPTIONS,
+    PRIORITY_OPTIONS,
+)
 
 
 class ParsedDateTime(DateTime):
@@ -82,7 +55,7 @@ class Component(String):
     }
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value not in COMPONENT_OPTIONS:
+        if value not in COMPONENT_OPTIONS.enums:
             raise self.make_error("unrecognised_component", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
@@ -106,7 +79,7 @@ class Priority(String):
     }
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value not in PRIORITY_OPTIONS:
+        if value not in PRIORITY_OPTIONS.enums:
             raise self.make_error("unrecognised_priority", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
@@ -180,7 +153,7 @@ class Pocket(String):
     default_error_messages = {"unrecognised_pocket": "Unrecognised pocket"}
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if value not in POCKET_OPTIONS:
+        if value not in POCKET_OPTIONS.enums:
             raise self.make_error("unrecognised_pocket", input=value)
 
         return super()._deserialize(value, attr, data, **kwargs)
@@ -362,8 +335,8 @@ class Status(Schema):
     release_codename = String(required=True)
     status = StatusStatuses(required=True)
     description = String(allow_none=True)
-    component = Component(enum=COMPONENT_OPTIONS)
-    pocket = Pocket(enum=POCKET_OPTIONS)
+    component = Component(allow_none=True)
+    pocket = Pocket(allow_none=True)
 
 
 class CvePackage(Schema):
@@ -523,9 +496,9 @@ CVEsParameters = {
         description="Number of CVEs to omit from response. Defaults to 0.",
         allow_none=True,
     ),
-    "component": Component(
+    "component": List(
+        Component(),
         allow_none=True,
-        enum=COMPONENT_OPTIONS,
         description="Package component",
     ),
     "version": List(

--- a/webapp/types.py
+++ b/webapp/types.py
@@ -1,0 +1,51 @@
+"""
+Defines common types used in schemas and models.
+"""
+
+from sqlalchemy import Enum
+
+STATUS_STATUSES = Enum(
+    "released",
+    "DNE",
+    "needed",
+    "not-affected",
+    "deferred",
+    "needs-triage",
+    "ignored",
+    "pending",
+    name="statuses",
+)
+
+COMPONENT_OPTIONS = Enum("main", "universe", name="components")
+
+POCKET_OPTIONS = Enum(
+    "security",
+    "updates",
+    "esm-infra",
+    "esm-infra-legacy",
+    "esm-apps",
+    "soss",
+    "fips",
+    "fips-updates",
+    "ros-esm",
+    "realtime",
+    name="pockets",
+)
+
+PACKAGE_TYPE_OPTIONS = [
+    "python",
+    "conda",
+    "golang",
+    "unpackaged",
+    "deb",
+]
+
+PRIORITY_OPTIONS = Enum(
+    "unknown",
+    "negligible",
+    "low",
+    "medium",
+    "high",
+    "critical",
+    name="priorities",
+)


### PR DESCRIPTION
## Done

- Refactored imports so that they come from one place and we don't have to define changes repeatedly throughout the code. Continuation of [this discussion](https://github.com/canonical/ubuntu-com-security-api/pull/176#discussion_r1732675086) 

## QA

- There is no change to functionality being introduced here, so test should pass as expected

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14516
