### PR TITLE
Add flag to fetch notices without full CVE payloads

### DIFF
--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -242,6 +242,14 @@ NoticeParameters = {
         ),
         allow_none=True,
     ),
+    "cve_ids_only": Boolean(
+        description=(
+            "Controls if the response includes full CVE payloads"
+            "Default is `false`."
+        ),
+        load_default=False,
+        allow_none=True,
+    ),
 }
 
 NoticesParameters = {

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -294,6 +294,14 @@ NoticesParameters = {
         load_default=False,
         allow_none=True,
     ),
+    "cve_ids_only": Boolean(
+        description=(
+            "Controls if the response includes full CVE payloads"
+            "Default is `false`."
+        ),
+        load_default=False,
+        allow_none=True,
+    ),
 }
 
 

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -2,16 +2,22 @@ from typing import Generator
 
 from sqlalchemy.orm import Query
 
-from webapp.schemas import NoticeAPIDetailedSchema
+from webapp.schemas import NoticeAPISchema, NoticeAPIDetailedSchema
 
 
 def stream_notices(
-    notices_query: Query, offset: int, limit: int, total_count: int
+    notices_query: Query,
+    offset: int,
+    limit: int,
+    total_count: int,
+    cve_ids_only: bool,
 ) -> Generator[str, None, None]:
     """
     Stream notices as JSON object in chunks with one notice at a time.
     """
-    notice_schema = NoticeAPIDetailedSchema()
+    notice_schema = (
+        NoticeAPISchema() if cve_ids_only else NoticeAPIDetailedSchema()
+    )
     yield '{"notices":['
     first = True
     for notice in notices_query.offset(offset).limit(limit).yield_per(1):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -36,6 +36,7 @@ from webapp.schemas import (
     CVEsParameters,
     MessageSchema,
     MessageWithErrorsSchema,
+    NoticeAPISchema,
     NoticeAPIDetailedSchema,
     NoticeImportSchema,
     NoticeParameters,
@@ -426,7 +427,12 @@ def get_notice(notice_id, **kwargs):
             404,
         )
 
-    result = NoticeAPIDetailedSchema().dump(notice)
+    schema = (
+        NoticeAPISchema
+        if kwargs.get("cve_ids_only")
+        else NoticeAPIDetailedSchema
+    )
+    result = schema().dump(notice)
     response = jsonify(result)
     response.cache_control.max_age = SIX_HOURS_IN_SECONDS
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -441,6 +441,7 @@ def get_notices(**kwargs):
     offset: int = kwargs["offset"]
     order_by: Literal["oldest", "newest"] = kwargs["order"]
     show_hidden: bool = kwargs["show_hidden"]
+    cve_ids_only: bool = kwargs["cve_ids_only"]
 
     release: Optional[str] = kwargs.get("release")
     details: Optional[str] = kwargs.get("details")
@@ -511,7 +512,9 @@ def get_notices(**kwargs):
 
     response = Response(
         stream_with_context(
-            stream_notices(notices_query, offset, limit, total_count)
+            stream_notices(
+                notices_query, offset, limit, total_count, cve_ids_only
+            )
         ),
         content_type="application/json",
     )


### PR DESCRIPTION
## Done

Add a flag that when set to true returns a notice payload without  the `cves` key.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/notices.json?cve_ids_only=true
- Check the payload only contains `cves_ids` and not `cves`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/notices.{notice_id}json?cve_ids_only=true
- Check the payload only contains `cves_ids` and not `cves`
