### PR TITLE
Flatten the notices endpoint payloads to reduce increasing sizes

### DIFF
--- a/templates/swagger-ui.html
+++ b/templates/swagger-ui.html
@@ -9,8 +9,20 @@
   <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.12.0/swagger-ui.css" />
 </head>
 <body>
+  <div class="swagger-ui">
+    <div class="wrapper">
+      <div class="bg-light-yellow pa4">
+        <h1 class="mt0">Warning</h1>
+        <p>We have reduced the nesting of <code>notices</code> endpoints due to an increase in the size of the payloads that compromised the availability of the service. For each notice, you will still find IDs for linked CVEs, but if you need further detail on the linked CVEs, an additional requests will be required.</p>
+        <p>We preserved the previous endpoints behaviour on different paths, but the performance will likely not see many improvments, if you wish to use them they are:</p>
+        <ul>
+          <li><strong>/security/compat/notices.json</strong></li>
+          <li><strong>/security/compat/notices/{notice_id}.json</strong></li>
+        </ul>
+      </div>
+    </div>
+  </div>
   <div id="swagger-ui-container"></div>
-
   <script type="text/javascript">
     var ui = SwaggerUIBundle({
       url: "/security/api/spec.json",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -951,6 +951,15 @@ class TestRoutes(BaseTestCase):
 
         assert response.status_code == 200
         assert response.json["cves_ids"] == self.models["notice"].cves_ids
+        assert (
+            response.json["cves"][0]["id"] == self.models["notice"].cves[0].id
+        )
+        assert response.json["cves"][0]["notices_ids"] == [
+            self.models["notice"].id
+        ]
+
+        # related_notices in payload
+        assert response.json["related_notices"] == []
 
         # Test request limit
         response = self.client.get("/security/notices.json?limit=21")
@@ -968,6 +977,16 @@ class TestRoutes(BaseTestCase):
         response = self.client.get(f"/security/notices.json?cves={cve_id}")
         assert response.status_code == 200
         assert cve_id in response.json["notices"][0]["cves_ids"]
+        assert (
+            response.json["notices"][0]["cves"][0]["id"]
+            == self.models["notice"].cves[0].id
+        )
+        assert response.json["notices"][0]["cves"][0]["notices_ids"] == [
+            self.models["notice"].id
+        ]
+
+        # related_notices in payload
+        assert response.json["notices"][0]["related_notices"] == []
 
         response = self.client.get(
             f"/security/notices.json?cves={cve_id},{test_cve.id}"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -19,6 +19,8 @@ from webapp.views import (
     get_cves,
     get_notice,
     get_notices,
+    get_notice_v2,
+    get_notices_v2,
     get_page_notices,
     get_release,
     get_releases,
@@ -64,12 +66,25 @@ app.add_url_rule(
 
 app.add_url_rule(
     "/security/notices/<notice_id>.json",
-    view_func=get_notice,
+    view_func=get_notice_v2,
     provide_automatic_options=False,
 )
 
 app.add_url_rule(
     "/security/notices.json",
+    view_func=get_notices_v2,
+    provide_automatic_options=False,
+)
+
+
+app.add_url_rule(
+    "/security/compat/notices/<notice_id>.json",
+    view_func=get_notice,
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/compat/notices.json",
     view_func=get_notices,
     provide_automatic_options=False,
 )
@@ -156,9 +171,11 @@ views_to_register_in_docs = [
     get_cves,
     bulk_upsert_cve,
     delete_cve,
-    get_notice,
     get_page_notices,
+    get_notice,
     get_notices,
+    get_notice_v2,
+    get_notices_v2,
     create_notice,
     update_notice,
     delete_notice,

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -210,20 +210,12 @@ class Notice(db.Model):
     @hybrid_property
     def related_notices(self):
         seen_notices_ids = [self.id]
-        related_notices = []
         for cve in self.cves:
             for notice in cve.notices:
                 if notice.id not in seen_notices_ids:
                     if not notice.is_hidden:
-                        related_notices.append(
-                            {
-                                "id": notice.id,
-                                "packages": ", ".join(notice.packages),
-                            }
-                        )
+                        yield notice
                     seen_notices_ids.append(notice.id)
-
-        return related_notices
 
 
 class Release(db.Model):

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -2,7 +2,7 @@ from typing import Generator
 
 from sqlalchemy.orm import Query
 
-from webapp.schemas import NoticeAPISchema, NoticeAPIDetailedSchema
+from webapp.schemas import NoticeAPIDetailedSchema
 
 
 def stream_notices(
@@ -10,14 +10,11 @@ def stream_notices(
     offset: int,
     limit: int,
     total_count: int,
-    cve_ids_only: bool,
 ) -> Generator[str, None, None]:
     """
     Stream notices as JSON object in chunks with one notice at a time.
     """
-    notice_schema = (
-        NoticeAPISchema() if cve_ids_only else NoticeAPIDetailedSchema()
-    )
+    notice_schema = NoticeAPIDetailedSchema()
     yield '{"notices":['
     first = True
     for notice in notices_query.offset(offset).limit(limit).yield_per(1):


### PR DESCRIPTION
## Done

Changed both the `/security/notices.json` and `/security/notices/<notice_id>.json` endpoints to reduce the size of the payload, as with the current structure the resulting payloads sizes for fetching the latest 20 notices are bigger than 100Mb, so we need to reduce that.

The actual change for each notice object are:

- `related_notices` becomes a flat list of of notice IDs: ["USN-7007-1",  "USN-7009-1",  "USN-7019-1"]
- ` cves` is still an array of CVE objects but the object itself is now much smaller and contains only two keys `id` which is the ID of the CVE and `notices_ids` which is a flat list of notice IDs that are linked to the CVE.

We recognize this is a breaking change and tried to minimize the impact by keeping the preexisting on a different path, but would still recommend that those are used as a last resource:
- `/security/compat/notices.json`
- `/security/compat/notices/<notice_id>.json`


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/


