### PR TITLE
[WD-20320] feat: Increase cve results limit to 100

### DIFF
--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -509,8 +509,8 @@ CVEsParameters = {
     ),
     "package": String(description="Package name", allow_none=True),
     "limit": Int(
-        validate=Range(min=1, max=20),
-        description="Number of CVEs per response. Defaults to 10. Max 20.",
+        validate=Range(min=1, max=100),
+        description="Number of CVEs per response. Defaults to 10. Max 100.",
         allow_none=True,
     ),
     "offset": Int(


### PR DESCRIPTION
## Done

- Increase the limit to 100

## QA

- Check out this feature branch
- Run the site using the commands `docker compose up -d` and  `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Pass all of the following limit values in the url and verify that it works:
  - localhost:8030/security/cves.json?q=&limit=10
  - localhost:8030/security/cves.json?q=&limit=20
  - localhost:8030/security/cves.json?q=&limit=40
  - localhost:8030/security/cves.json?q=&limit=60
  - localhost:8030/security/cves.json?q=&limit=80
  - localhost:8030/security/cves.json?q=&limit=100

## Issue / Card

Fixes #[WD-20320](https://warthogs.atlassian.net/browse/WD-20320)


[WD-20320]: https://warthogs.atlassian.net/browse/WD-20320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ