### PR TITLE
Set ephemeral storage limits

### DIFF
--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -81,5 +81,8 @@ spec:
             timeoutSeconds: 3
 
           resources:
+            requests:
+              ephemeral-storage: 128Mi
             limits:
+              ephemeral-storage: 1Gi
               memory: 2G

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -81,5 +81,8 @@ spec:
             timeoutSeconds: 3
 
           resources:
+            requests:
+              ephemeral-storage: 128Mi
             limits:
+              ephemeral-storage: 1Gi
               memory: 1G


### PR DESCRIPTION
## Done

- Set ephemeral storage limits to mitigate likelihood of pod eviction

## Rationale

Limits were based on direct inspection of multiple running pods across both services, ranging in age from 24 hours to 43 days. All showed consistent usage under 60Mi, so a 128Mi request and 1Gi limit were chosen to accommodate temporary increases in disk activity without risking node-level pressure or eviction.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been reso
lved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
