### PR TITLE
feat: disable json compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:noble AS python-dependencies
 RUN apt-get update && apt-get install --no-install-recommends --yes \
 python3-pip python3-setuptools python3-wheel python3-venv \
-build-essential
+build-essential git # remove git after review
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 config set global.disable-pip-version-check true
 RUN python3 -m venv /venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/canonicalwebteam.flask-base@add-compression-override-option#egg=canonicalwebteam.flask-base
+canonicalwebteam.flask-base @ git+https://github.com/canonical/canonicalwebteam.flask-base@add-compression-override-option
 alchemy-mock==0.4.3
 apispec==4.7.1
 flask-apispec==0.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==2.2.2.dev1
+git+https://github.com/canonical/canonicalwebteam.flask-base@add-compression-override-option#egg=canonicalwebteam.flask-base
 alchemy-mock==0.4.3
 apispec==4.7.1
 flask-apispec==0.11.4

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,10 +28,39 @@ from webapp.views import (
     update_notice,
     update_release,
 )
+# Flask compress options
+COMPRESS_MIMETYPES = [
+    'text/html',
+    'text/css',
+    'text/plain',
+    'text/xml',
+    'text/x-component',
+    'text/javascript',
+    'application/x-javascript',
+    'application/javascript',
+    'application/manifest+json',
+    'application/vnd.api+json',
+    'application/xml',
+    'application/xhtml+xml',
+    'application/rss+xml',
+    'application/atom+xml',
+    'application/vnd.ms-fontobject',
+    'application/x-font-ttf',
+    'application/x-font-opentype',
+    'application/x-font-truetype',
+    'image/svg+xml',
+    'image/x-icon',
+    'image/vnd.microsoft.icon',
+    'font/ttf',
+    'font/eot',
+    'font/otf',
+    'font/opentype',
+]
 
 app = FlaskBase(
     __name__,
     "ubuntu-com-security-api",
+    compress_mimetypes=COMPRESS_MIMETYPES
 )
 
 app.config.update(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,39 +28,38 @@ from webapp.views import (
     update_notice,
     update_release,
 )
+
 # Flask compress options
 COMPRESS_MIMETYPES = [
-    'text/html',
-    'text/css',
-    'text/plain',
-    'text/xml',
-    'text/x-component',
-    'text/javascript',
-    'application/x-javascript',
-    'application/javascript',
-    'application/manifest+json',
-    'application/vnd.api+json',
-    'application/xml',
-    'application/xhtml+xml',
-    'application/rss+xml',
-    'application/atom+xml',
-    'application/vnd.ms-fontobject',
-    'application/x-font-ttf',
-    'application/x-font-opentype',
-    'application/x-font-truetype',
-    'image/svg+xml',
-    'image/x-icon',
-    'image/vnd.microsoft.icon',
-    'font/ttf',
-    'font/eot',
-    'font/otf',
-    'font/opentype',
+    "text/html",
+    "text/css",
+    "text/plain",
+    "text/xml",
+    "text/x-component",
+    "text/javascript",
+    "application/x-javascript",
+    "application/javascript",
+    "application/manifest+json",
+    "application/vnd.api+json",
+    "application/xml",
+    "application/xhtml+xml",
+    "application/rss+xml",
+    "application/atom+xml",
+    "application/vnd.ms-fontobject",
+    "application/x-font-ttf",
+    "application/x-font-opentype",
+    "application/x-font-truetype",
+    "image/svg+xml",
+    "image/x-icon",
+    "image/vnd.microsoft.icon",
+    "font/ttf",
+    "font/eot",
+    "font/otf",
+    "font/opentype",
 ]
 
 app = FlaskBase(
-    __name__,
-    "ubuntu-com-security-api",
-    compress_mimetypes=COMPRESS_MIMETYPES
+    __name__, "ubuntu-com-security-api", compress_mimetypes=COMPRESS_MIMETYPES
 )
 
 app.config.update(


### PR DESCRIPTION
## Done

- Disabled json response compression

**Note: update the flask-base dependency once 2.6.1 is merged** 

## QA

- Clone this branch and this env file:
```env
PORT=8030
DEVEL=true
FLASK_APP=webapp.app
FLASK_DEBUG=true
SECRET_KEY=local_development_fake_key
DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/testdb
DOTRUN_DOCKER_COMPOSE_ACTIONS=start:serve:test:test-python
```
- Run the api
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
set -a
source .env
set +a
python -m venv .venv
source .venv/bin/activate
pip install -r requirements.txt
./entrypoint 0.0.0.0:8030 
```
- Using curl, make a request to 0.0.0.0:8030 and confirm that the `Content-Encoding` header is absent.
```bash
curl --head --compressed http://0.0.0.0:8030
```
- compare to staging, which should have a `Content-Encoding`  header
```bash
curl --head --compressed https://staging.ubuntu.com/security/cves.json?limit=1
```
- compare to another similar branch e.g. `add-oauth`, which should have a `Content-Encoding`  header
```bash
git checkout add-oauth
./entrypoint 0.0.0.0:8030
curl --head --compressed http://0.0.0.0:8030/security/cves.json?limit=1
```

## Issue / Card

Fixes [WD-23733](https://warthogs.atlassian.net/browse/WD-23733)


[WD-23733]: https://warthogs.atlassian.net/browse/WD-23733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ