### PR TITLE
feat: added oauth authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.flask-base==2.2.2.dev1
 alchemy-mock==0.4.3
 apispec==4.7.1
 flask-apispec==0.11.4
-launchpadlib==1.11.0
+launchpadlib==2.1.0
 macaroonbakery==1.3.4
 marshmallow==3.20.2
 python-dateutil==2.8.2

--- a/scripts/create-cves.py
+++ b/scripts/create-cves.py
@@ -4,33 +4,40 @@
 import argparse
 import json
 import os
-from datetime import datetime
 from http.cookiejar import MozillaCookieJar
 
 # Packages
 from macaroonbakery import httpbakery
 
-
 parser = argparse.ArgumentParser(
-    description="Create or update CVEs in the API"
+    description="Create or update CVEs in the API",
 )
 parser.add_argument("file_path", action="store", type=str)
 parser.add_argument(
-    "--host", action="store", type=str, default="http://localhost:8030"
+    "--host",
+    action="store",
+    type=str,
+    default="http://localhost:8109",
+)
+parser.add_argument(
+    "--auth",
+    action="store",
+    type=str,
+    default="jujucharms",
 )
 args = parser.parse_args()
 
 
+notice_endpoint = f"{args.host}/security/updates/oauth/cves.json"
+
 client = httpbakery.Client(cookies=MozillaCookieJar(".login"))
 
-if os.path.exists(client.cookies.filename):
-    client.cookies.load(ignore_discard=True)
-
-notice_endpoint = f"{args.host}/security/cves.json"
-
-# Make a first call to make sure we are logged in
-response = client.request("PUT", url=notice_endpoint)
-client.cookies.save(ignore_discard=True)
+if args.auth != "oauth":
+    if os.path.exists(client.cookies.filename):
+        client.cookies.load(ignore_discard=True)
+    # Make a first call to make sure we are logged in
+    response = client.request("PUT", url=notice_endpoint)
+    client.cookies.save(ignore_discard=True)
 
 # Post the stuff
 with open(args.file_path) as json_file:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -17,14 +17,15 @@ from webapp.views import (
     delete_release,
     get_cve,
     get_cves,
+    get_flat_notices,
     get_notice,
-    get_notices,
     get_notice_v2,
+    get_notices,
     get_notices_v2,
     get_page_notices,
-    get_flat_notices,
     get_release,
     get_releases,
+    test_authorization_required,
     update_notice,
     update_release,
 )
@@ -46,7 +47,7 @@ app.config.update(
         "APISPEC_SWAGGER_UI_URL": "/security/api/docs",
         "SQLALCHEMY_DATABASE_URI": os.environ["DATABASE_URL"],
         "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-    }
+    },
 )
 
 init_db(app)
@@ -170,6 +171,13 @@ app.add_url_rule(
     "/security/updates/releases/<release_codename>.json",
     view_func=delete_release,
     methods=["DELETE"],
+    provide_automatic_options=False,
+)
+## Remove after PR
+app.add_url_rule(
+    "/security/updates/authtest.json",
+    view_func=test_authorization_required,
+    methods=["PUT"],
     provide_automatic_options=False,
 )
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -13,8 +13,9 @@ from flask import (
 from flask_apispec import marshal_with, use_kwargs
 from sqlalchemy import asc, case, desc, func, or_, text
 from sqlalchemy.exc import DataError, IntegrityError
-from sqlalchemy.orm import Query, load_only, selectinload, aliased
-from webapp.auth import authorization_required
+from sqlalchemy.orm import Query, aliased, load_only, selectinload
+
+from webapp.auth import authorization_required, oauth_authorization_required
 from webapp.database import db
 from webapp.models import (
     CVE,
@@ -31,6 +32,8 @@ from webapp.schemas import (
     CVEParameter,
     CVEsAPISchema,
     CVEsParameters,
+    FlatNoticesAPISchema,
+    FlatNoticesParameters,
     MessageSchema,
     MessageWithErrorsSchema,
     NoticeAPIDetailedSchema,
@@ -40,10 +43,8 @@ from webapp.schemas import (
     NoticesAPISchema,
     NoticesAPISchemaV2,
     NoticesParameters,
-    PageNoticesParameters,
     PageNoticesAPISchema,
-    FlatNoticesAPISchema,
-    FlatNoticesParameters,
+    PageNoticesParameters,
     ReleaseAPISchema,
     ReleasesAPISchema,
     ReleaseSchema,
@@ -891,6 +892,14 @@ def delete_release(release_codename):
     return make_response(
         jsonify({"message": f"Release {release_codename} deleted"}), 200
     )
+
+
+# Remove after PR review
+@oauth_authorization_required
+def test_authorization_required():
+    """Test method for auth."""
+    print("Authorization test function called.")
+    return "This is a test function for authorization_required decorator.", 200
 
 
 def _sort_by_priority(cves_query):


### PR DESCRIPTION

## Done
- Added a method to allow oauth interactive authentication

## QA

- Check out this feature branch
- Run the site using:
```bash
python -m venv .venv
source .venv/bin/activate
pip install -r requirements.txt
./entrypoint 0.0.0.0:8030
```
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Upload a file by:
```bash
cd scripts
python create-cves.py --auth oauth payloads/cves.json 
```
- Follow the url, and after granting access, check the logs for a success message:
` User is authorized...`
- Run through the following [QA steps](https://canonical-web-and-design.github
.io/practices/workflow/qa-steps.html)


## Issue / Card

Fixes [WD-22499](https://warthogs.atlassian.net/browse/WD-22499?atlOrigin=eyJpIjoiNDBhMDg0MDBkNTYwNDgzMWIyOWI2ODg5ODczYWM2MTgiLCJwIjoiaiJ9)

