### PR TITLE
feat: added raw config for flat notices

### DIFF
--- a/konf/raw-site-flat-notices.yaml
+++ b/konf/raw-site-flat-notices.yaml
@@ -1,0 +1,88 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ubuntu-com-security-api-flat-notices
+spec:
+  selector:
+    app: ubuntu-com-security-api-flat-notices
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ubuntu-com-security-api-flat-notices
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ubuntu-com-security-api-flat-notices
+  template:
+    metadata:
+      labels:
+        app: ubuntu-com-security-api-flat-notices
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - ubuntu-com-security-api-flat-notices
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: ubuntu-com-security-api-flat-notices
+          image: prod-comms.ps5.docker-registry.canonical.com/ubuntu-com-security-api:${TAG_TO_DEPLOY}
+
+          ports:
+            - name: http
+              containerPort: 80
+
+          env:
+            - name: TALISKER_NETWORKS
+              value: 10.0.0.0/8
+
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: ubuntu-com-security-api
+                  name: secret-keys
+
+            - name: HTTP_PROXY
+              value: "http://squid.internal:3128/"
+
+            - name: HTTPS_PROXY
+              value: "http://squid.internal:3128/"
+
+            - name: NO_PROXY
+              value: ".internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io"
+
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: database_url
+                  name: usn-db-url
+
+            - name: SENTRY_DSN
+              value: "https://1e974d641a14437e9573e8fe9958a252@sentry.is.canonical.com//48"
+
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            periodSeconds: 5
+            timeoutSeconds: 3
+
+          resources:
+            requests:
+              ephemeral-storage: 128Mi
+            limits:
+              ephemeral-storage: 1Gi
+              memory: 2G


### PR DESCRIPTION
## Done

- Added a new deployment for flat notices
- After merging, also merge https://github.com/canonical/ubuntu.com/pull/15410

## QA

- This branch has been deployed to staging, check that the [Jenkins](https://jenkins.canonical.com/webteam/job/ubuntu-com-security-api/lastBuild/console) job logs completed successfully, and that the `ubuntu-security-api-flat-notices` pods are working.

## Issue / Card

Fixes [WD-24490](https://warthogs.atlassian.net/browse/WD-24490?atlOrigin=eyJpIjoiYzhjN2JkOTNlZjQwNGE5MGJhMzIyM2NiNzlmYjUyNjYiLCJwIjoiaiJ9)




[WD-24490]: https://warthogs.atlassian.net/browse/WD-24490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ