### PR TITLE
feat: Add released cves endpoint

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -17,6 +17,7 @@ from webapp.views import (
     delete_release,
     get_cve,
     get_cves,
+    get_released_cves,
     get_notice,
     get_notices,
     get_notice_v2,
@@ -62,6 +63,12 @@ app.add_url_rule(
 app.add_url_rule(
     "/security/cves.json",
     view_func=get_cves,
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/released/cves.json",
+    view_func=get_released_cves,
     provide_automatic_options=False,
 )
 

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -592,6 +592,35 @@ class CVESummaryV2(Schema):
         render_module = orjson
 
 
+class ReleasedCVEAPISchema(Schema):
+    id = String(required=True)
+    description = String(allow_none=True)
+    codename = String(allow_none=True)
+    priority = String(allow_none=True)
+    published = ParsedDateTime(allow_none=True)
+    updated_at = ParsedDateTime(allow_none=True)
+    references = List(String())
+    bugs = List(String())
+    patches = Dict(
+        keys=String(),
+        values=List(String(), required=False),
+        allow_none=True,
+    )
+
+    class Meta:
+        render_module = orjson
+
+
+class ReleasedCVEsAPISchema(CVESchema):
+    cves = List(Nested(ReleasedCVEAPISchema))
+    offset = Int(allow_none=True)
+    limit = Int(allow_none=True)
+    total_results = Int()
+
+    class Meta:
+        render_module = orjson
+
+
 class NoticeAPIDetailedSchemaV2(NoticeSchema):
     notice_type = String(data_key="type")
     cves = List(Nested(CVESummaryV2))
@@ -765,6 +794,32 @@ CVEsParameters = {
             "Default is False."
         ),
         allow_none=True,
+    ),
+}
+
+ReleasedCVEsParameters = {
+    "package": String(description="Package name", allow_none=True),
+    "limit": Int(
+        validate=Range(min=1, max=20),
+        description="Number of CVEs per response. Defaults to 10. Max 20.",
+        allow_none=True,
+    ),
+    "offset": Int(
+        description="Number of CVEs to omit from response. Defaults to 0.",
+        allow_none=True,
+    ),
+    "version": List(
+        String(),
+        description="List of release codenames ",
+        allow_none=True,
+    ),
+    "order": String(
+        load_default="descending",
+        enum=["oldest, descending, ascending"],
+        description=(
+            "Select `ascending` or `oldest` (depreciated) for ASC order;"
+            "leave empty for descending order"
+        ),
     ),
 }
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -11,7 +11,7 @@ from flask import (
     stream_with_context,
 )
 from flask_apispec import marshal_with, use_kwargs
-from sqlalchemy import asc, case, desc, func, or_, text
+from sqlalchemy import asc, case, desc, func, or_, text, distinct
 from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import Query, load_only, selectinload, aliased
 from webapp.auth import authorization_required
@@ -31,6 +31,8 @@ from webapp.schemas import (
     CVEParameter,
     CVEsAPISchema,
     CVEsParameters,
+    ReleasedCVEsAPISchema,
+    ReleasedCVEsParameters,
     MessageSchema,
     MessageWithErrorsSchema,
     NoticeAPIDetailedSchema,
@@ -232,6 +234,74 @@ def get_cves(**kwargs):
             "offset": offset,
             "limit": limit,
             "total_results": pagination.total,
+        }
+    )
+
+    response = jsonify(result)
+    response.cache_control.max_age = TEN_MINUTES_IN_SECONDS
+    return response
+
+
+@marshal_with(ReleasedCVEsAPISchema, code=200)
+@marshal_with(MessageWithErrorsSchema, code=422)
+@use_kwargs(ReleasedCVEsParameters, location="query")
+def get_released_cves(**kwargs):
+    package: Optional[str] = kwargs.get("package")
+    limit: int = kwargs.get("limit", 10)
+    offset: int = kwargs.get("offset", 0)
+    versions: Optional[List[str]] = kwargs.get("version")
+
+    # Base status query for released statuses
+    status_query = db.session.query(Status.cve_id).filter(
+        Status.status == "released"
+    )
+
+    if versions:
+        status_query = status_query.filter(
+            Status.release_codename.in_(versions)
+        )
+
+    if package:
+        lowered_package = f"%{package.lower()}%"
+        status_query = status_query.filter(
+            func.lower(Status.package_name).like(lowered_package)
+        )
+
+    # Subquery of released CVE IDs with optional filters
+    released_cve_ids_subquery = status_query.distinct().subquery()
+
+    # Main query: CVEs that are active and have a released status
+    cve_query = (
+        db.session.query(CVE)
+        .join(
+            released_cve_ids_subquery,
+            CVE.id == released_cve_ids_subquery.c.cve_id,
+        )
+        .filter(CVE.status == "active")
+        .order_by(CVE.published.desc().nullslast())
+        .offset(offset)
+        .limit(limit)
+    )
+
+    cves = cve_query.all()
+
+    # Count distinct active CVEs with released statuses
+    total_results = (
+        db.session.query(func.count(distinct(CVE.id)))
+        .join(
+            released_cve_ids_subquery,
+            CVE.id == released_cve_ids_subquery.c.cve_id,
+        )
+        .filter(CVE.status == "active")
+        .scalar()
+    )
+
+    result = ReleasedCVEsAPISchema().dump(
+        {
+            "cves": cves,
+            "offset": offset,
+            "limit": limit,
+            "total_results": total_results,
         }
     )
 


### PR DESCRIPTION
## Done

- Added released cves endpoint
- Added relevant tests

## QA

- View the site locally in your web browser at: http://0.0.0.0:8030/released/cves.json
- Check ability to filter by package and/or version (cves are filtered by released status by default)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-23995