### PR TITLE
feat: Add cves sitemap endpoint

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1037,6 +1037,15 @@ class TestRoutes(BaseTestCase):
             f"Expected: {expected_version_package_ids}\n"
             f"Got: {returned_version_package_ids}"
         )
+        
+    def test_sitemap_cves(self):
+        response = self.client.get("/security/sitemap/cves.json")
+
+        assert response.status_code == 200
+        # Check that the response includes id and publish date
+        cves = response.json["cves"]
+        for cve in cves:
+            assert set(cve.keys()) == {"id", "published"}
 
     def test_bulk_upsert_cves_returns_422_for_invalid_cve(self):
         cve = payloads.cve1.copy()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1037,7 +1037,7 @@ class TestRoutes(BaseTestCase):
             f"Expected: {expected_version_package_ids}\n"
             f"Got: {returned_version_package_ids}"
         )
-        
+
     def test_sitemap_cves(self):
         response = self.client.get("/security/sitemap/cves.json")
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -18,6 +18,7 @@ from webapp.views import (
     get_cve,
     get_cves,
     get_released_cves,
+    get_sitemap_cves,
     get_notice,
     get_notices,
     get_notice_v2,
@@ -97,6 +98,12 @@ app.add_url_rule(
 app.add_url_rule(
     "/security/released/cves.json",
     view_func=get_released_cves,
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/sitemap/cves.json",
+    view_func=get_sitemap_cves,
     provide_automatic_options=False,
 )
 

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -667,7 +667,7 @@ class SitemapsCVESchema(Schema):
         render_module = orjson
 
 
-class SitemapCVEsAPISchema(CVESchema):
+class SitemapCVEsAPISchema(Schema):
     cves = List(Nested(SitemapsCVESchema))
     offset = Int(allow_none=True)
     limit = Int(allow_none=True)

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -659,6 +659,24 @@ class PageNoticesAPISchema(Schema):
         render_module = orjson
 
 
+class SitemapsCVESchema(Schema):
+    id = String(required=True)
+    published = ParsedDateTime(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class SitemapCVEsAPISchema(CVESchema):
+    cves = List(Nested(SitemapsCVESchema))
+    offset = Int(allow_none=True)
+    limit = Int(allow_none=True)
+    total_results = Int()
+
+    class Meta:
+        render_module = orjson
+
+
 class FlatNoticeSchema(Schema):
     id = String(
         required=True,
@@ -726,6 +744,18 @@ CVEParameter = {
             "True or False if you want to select hidden notices. "
             "Default is False."
         ),
+        allow_none=True,
+    ),
+}
+
+CVESitemapParameters = {
+    "limit": Int(
+        validate=Range(min=1, max=100),
+        description="Number of CVEs per response. Defaults to 10. Max 100.",
+        allow_none=True,
+    ),
+    "offset": Int(
+        description="Number of CVEs to omit from response. Defaults to 0.",
         allow_none=True,
     ),
 }

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -799,12 +799,19 @@ def get_sitemap_cves(**kwargs):
         .all()
     )
 
-    return {
-        "cves": cves,
-        "offset": offset,
-        "limit": limit,
-        "total_results": total_results,
-    }
+    result = SitemapCVEsAPISchema().dump(
+        {
+            "cves": cves,
+            "offset": offset,
+            "limit": limit,
+            "total_results": total_results,
+        }
+    )
+
+    response = jsonify(result)
+    response.cache_control.public = True
+    response.cache_control.max_age = 43200
+    return response
 
 
 @authorization_required


### PR DESCRIPTION
## Done

- Created endpoint for cve sitemaps
  - Should return only 2 fields per cve, id and publish date

## QA

- View the site locally in your web browser at: http://0.0.0.0:8030/
- Please follow the QA steps listed in the [related pr](https://github.com/canonical/ubuntu.com/pull/15453) 


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24180