### PR TITLE
fix: Fix flat notices schema and update page notices

### DIFF
--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -632,8 +632,14 @@ class NoticeAPIDetailedSchemaV2(NoticeSchema):
         render_module = orjson
 
 
-class PageNoticeAPISchema(NoticeSchema):
+class PageNoticeAPISchema(Schema):
+    id = String(
+        required=True,
+        validate=Regexp(r"(USN|LSN|SSN)-\d{1,5}-\d{1,2}"),
+    )
     cves_ids = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
+    published = ParsedDateTime(required=True)
+    summary = String(required=True)
     notice_type = String(data_key="type")
     releases = List(Nested(NoticeReleasesSchema))
 
@@ -665,7 +671,7 @@ class FlatNoticeSchema(Schema):
         render_module = orjson
 
 
-class FlatNoticesAPISchema(NoticeSchema):
+class FlatNoticesAPISchema(Schema):
     notices = List(Nested(FlatNoticeSchema))
     offset = Int(allow_none=True)
     limit = Int(allow_none=True)

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -642,6 +642,8 @@ class PageNoticeAPISchema(Schema):
     summary = String(required=True)
     notice_type = String(data_key="type")
     releases = List(Nested(NoticeReleasesSchema))
+    title = String(required=True)
+    details = String(allow_none=True, data_key="description")
 
     class Meta:
         render_module = orjson


### PR DESCRIPTION
## Done

- Fix flat notices schema wrapper 
- Drive by:
  - Update page notices schema to for current reduced UI need

## QA
- View the site locally in your web browser at: http://0.0.0.0:8030/security/flat/notices.json and ensure the returned json matches the schema
- View the site locally in your web browser at: http://0.0.0.0:8030/security/page/notices.json
- See that the only returned fields in the notices list are  `id`, `summary`, `releases`, `cve_ids`, `published`, `type`, `title`, and `description`. These are the only fields consumed by the notices UI and rss feeds on u.com 


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-25026