### PR TITLE
feat: Apply base notices refactor

### DIFF
--- a/migrations/versions/fc4b8f31d182_add_indexes_for_notice_search_.py
+++ b/migrations/versions/fc4b8f31d182_add_indexes_for_notice_search_.py
@@ -1,0 +1,41 @@
+"""Add indexes for notice search optimization
+
+Revision ID: fc4b8f31d182
+Revises: 5ad36b3ca4ba
+Create Date: 2025-08-18 09:56:49.713094
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fc4b8f31d182'
+down_revision = '5ad36b3ca4ba'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create GIN indexes for full-text search
+    # assumes pg_trgm already exists
+    
+    # Trigram indexes for full-text search
+    op.execute("CREATE INDEX IF NOT EXISTS idx_notice_id_trgm ON notice USING gin (id gin_trgm_ops)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_notice_title_trgm ON notice USING gin (title gin_trgm_ops)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_notice_details_trgm ON notice USING gin (details gin_trgm_ops)")
+
+    # B-tree indexes on notice_cves for fast joins
+    op.execute("CREATE INDEX IF NOT EXISTS idx_notice_cves_notice_id ON notice_cves (notice_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_notice_cves_cve_id ON notice_cves (cve_id)")
+
+    # B-tree index on release.codename for filtering
+    op.execute("CREATE INDEX IF NOT EXISTS idx_release_codename ON release (codename)")
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS idx_release_codename")
+    op.execute("DROP INDEX IF EXISTS idx_notice_cves_cve_id")
+    op.execute("DROP INDEX IF EXISTS idx_notice_cves_notice_id")
+    op.execute("DROP INDEX IF EXISTS idx_notice_details_trgm")
+    op.execute("DROP INDEX IF EXISTS idx_notice_title_trgm")
+    op.execute("DROP INDEX IF EXISTS idx_notice_id_trgm")

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, deferred
 
 from webapp.database import db
 from webapp.types import (
@@ -171,7 +171,7 @@ class Notice(db.Model):
     summary = Column(String)
     details = Column(String)
     instructions = Column(String)
-    release_packages = Column(JSON)
+    release_packages = deferred(Column(JSON))
     cves = relationship("CVE", secondary=notice_cves, back_populates="notices")
     references = Column(JSON)
     is_hidden = Column(Boolean, nullable=False)


### PR DESCRIPTION
## Done

- Refactored get_notices_v2 where applicable 
- Added gin and b-tree indexes for performance  

## QA

- View the site locally in your web browser at: http://0.0.0.0:8030/security/notices.json
- Payload correctness is covered in unit tests but please test for speed against available parameters eg:
  - http://0.0.0.0:8030/security/notices.json?release=jammy   - http://0.0.0.0:8030/security/notices.json?details=linux
  - http://0.0.0.0:8030/security/notices.json?cve_id=CVE-2025-23146
  - http://0.0.0.0:8030/security/notices.json?cve_ids=CVE-2025-23146,CVE-2025-37862
  - Please also test with a combination of these

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22336
