### PR TITLE
feat: Add notices sitemap endpoint

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1380,6 +1380,15 @@ class TestRoutes(BaseTestCase):
             "errors", []
         )
 
+    def test_sitemap_notices(self):
+        response = self.client.get("/security/sitemap/notices.json")
+
+        assert response.status_code == 200
+        # Check that the response includes id and publish date
+        notices = response.json["notices"]
+        for notice in notices:
+            assert set(notice.keys()) == {"id", "published"}
+
     def test_create_usn(self):
         response = self.client.post(
             "/security/updates/notices.json", json=payloads.notice

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -20,6 +20,7 @@ from webapp.views import (
     get_flat_notices,
     get_released_cves,
     get_sitemap_cves,
+    get_sitemap_notices,
     get_notice,
     get_notice_v2,
     get_notices,
@@ -104,6 +105,12 @@ app.add_url_rule(
 app.add_url_rule(
     "/security/sitemap/cves.json",
     view_func=get_sitemap_cves,
+    provide_automatic_options=False,
+)
+
+app.add_url_rule(
+    "/security/sitemap/notices.json",
+    view_func=get_sitemap_notices,
     provide_automatic_options=False,
 )
 

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -400,6 +400,18 @@ FlatNoticesParameters = {
     ),
 }
 
+NoticeSitemapParameters = {
+    "limit": Int(
+        validate=Range(min=1, max=100),
+        description="Number of Notices per response. Defaults to 10. Max 100.",
+        allow_none=True,
+    ),
+    "offset": Int(
+        description="Number of Notices to omit from response. Defaults to 0.",
+        allow_none=True,
+    ),
+}
+
 
 # Release
 # --
@@ -669,6 +681,24 @@ class SitemapsCVESchema(Schema):
 
 class SitemapCVEsAPISchema(Schema):
     cves = List(Nested(SitemapsCVESchema))
+    offset = Int(allow_none=True)
+    limit = Int(allow_none=True)
+    total_results = Int()
+
+    class Meta:
+        render_module = orjson
+
+
+class SitemapsNoticeSchema(Schema):
+    id = String(required=True)
+    published = ParsedDateTime(allow_none=True)
+
+    class Meta:
+        render_module = orjson
+
+
+class SitemapNoticesAPISchema(Schema):
+    notices = List(Nested(SitemapsNoticeSchema))
     offset = Int(allow_none=True)
     limit = Int(allow_none=True)
     total_results = Int()


### PR DESCRIPTION
## Done

- Added end point to serve notice sitemaps on u.com

## QA

- View the site locally in your web browser at: http://0.0.0.0:8030/security/sitemap/notices.json
- From here please follow the QA steps in the relevant [u.com pr](https://github.com/canonical/ubuntu.com/pull/15495)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24181
