### PR TITLE
feat: check for stale pool connections

### DIFF
--- a/webapp/database.py
+++ b/webapp/database.py
@@ -31,7 +31,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy  # noqa: E402
 from sqlalchemy import exc
 
-db = SQLAlchemy(session_options={"autoflush": False})
+db = SQLAlchemy(session_options={"autoflush": False}, engine_options={"pool_pre_ping": True})
 
 
 def init_db(app):


### PR DESCRIPTION
## Done

Added a db engine flag, [`pool_pre_ping`](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping) to emit a test statement before a query is executed in order to determine if a pool connection is still alive first and reconnecting if required. See [here](https://docs.sqlalchemy.org/en/20/core/pooling.html#pool-disconnects-pessimistic).

This approach does not solve for dropped connections mid-transaction, but refreshes the connection pool should there be a stale connection

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- The branch has also been deployed to staging here, check that the job succeeded and the pods are ready

## Issue / Card

Fixes #
