### PR TITLE
fix: Fix Swagger UI rendering of CVSS4 nested schema fields

### DIFF
--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -328,9 +328,6 @@ cve9 = {
     "status": "active",
 }
 
-# Regression fixture for the CVSS4 import schema accepting explicit JSON
-# nulls throughout the nested chain, as some ingestion sources send null
-# rather than omitting these fields.
 cve_cvss4_null = {
     "id": "CVE-9999-0010",
     "codename": "testcodename10",
@@ -379,7 +376,6 @@ cve_cvss4_null = {
     "status": "active",
 }
 
-# Regression fixture for a top-level explicit JSON null on cvssV4 itself.
 cve_cvss4_top_level_null = {
     "id": "CVE-9999-0011",
     "codename": "testcodename11",

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -328,6 +328,90 @@ cve9 = {
     "status": "active",
 }
 
+# Regression fixture for the CVSS4 import schema accepting explicit JSON
+# nulls throughout the nested chain, as some ingestion sources send null
+# rather than omitting these fields.
+cve_cvss4_null = {
+    "id": "CVE-9999-0010",
+    "codename": "testcodename10",
+    "packages": [
+        {
+            "debian": "https://tracker.debian.org/pkg/mysql",
+            "name": "mysql",
+            "source": "https://ubuntu.com/security/cve?package=mysql",
+            "statuses": [
+                {
+                    "description": "",
+                    "release_codename": "testrelease",
+                    "status": "released",
+                    "pocket": "fips",
+                }
+            ],
+            "ubuntu": (
+                "https://packages.ubuntu.com/search?suite=all&section=all&arch"
+                "=any&searchon=sourcenames&keywords=mysql"
+            ),
+        }
+    ],
+    "impact": {
+        "baseMetricV4": {
+            "cvssV4": {
+                "version": "4.0",
+                "vectorString": None,
+                "baseMetrics": {
+                    "exploitabilityMetrics": None,
+                    "vulnerableSystemImpactMetrics": None,
+                    "subsequentSystemImpactMetrics": None,
+                },
+                "supplementalMetrics": None,
+                "environmentalMetrics": {
+                    "modifiedBaseMetrics": None,
+                    "securityRequirements": None,
+                },
+                "threatMetrics": None,
+                "baseScore": None,
+                "baseSeverity": None,
+            }
+        },
+    },
+    "published": "2020-12-01 12:42:54",
+    "priority": "negligible",
+    "status": "active",
+}
+
+# Regression fixture for a top-level explicit JSON null on cvssV4 itself.
+cve_cvss4_top_level_null = {
+    "id": "CVE-9999-0011",
+    "codename": "testcodename11",
+    "packages": [
+        {
+            "debian": "https://tracker.debian.org/pkg/mysql",
+            "name": "mysql",
+            "source": "https://ubuntu.com/security/cve?package=mysql",
+            "statuses": [
+                {
+                    "description": "",
+                    "release_codename": "testrelease",
+                    "status": "released",
+                    "pocket": "fips",
+                }
+            ],
+            "ubuntu": (
+                "https://packages.ubuntu.com/search?suite=all&section=all&arch"
+                "=any&searchon=sourcenames&keywords=mysql"
+            ),
+        }
+    ],
+    "impact": {
+        "baseMetricV4": {
+            "cvssV4": None,
+        },
+    },
+    "published": "2020-12-01 12:42:54",
+    "priority": "negligible",
+    "status": "active",
+}
+
 notice = {
     "cves": ["CVE-9999-0003", "CVE-9999-0004"],
     "id": "USN-9999-01",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1120,6 +1120,31 @@ class TestRoutes(BaseTestCase):
         )
         assert response.status_code == 200
 
+    def test_bulk_upsert_cve_accepts_null_cvss4_fields(self):
+        """
+        The CVSS4 import schema must keep accepting explicit JSON nulls
+        anywhere in the nested chain, since some ingestion sources send
+        null rather than omitting these fields.
+        """
+        response = self.client.put(
+            "/security/updates/cves.json",
+            json=[
+                payloads.cve_cvss4_null,
+                payloads.cve_cvss4_top_level_null,
+            ],
+        )
+        assert response.status_code == 200
+
+        response = self.client.get(
+            f"/security/cves/{payloads.cve_cvss4_null['id']}.json"
+        )
+        assert response.status_code == 200
+
+        response = self.client.get(
+            f"/security/cves/{payloads.cve_cvss4_top_level_null['id']}.json"
+        )
+        assert response.status_code == 200
+
     def test_delete_non_existing_cve_returns_404(self):
         response = self.client.delete(
             f"/security/updates/cves/{payloads.cve1['id']}.json"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1122,9 +1122,10 @@ class TestRoutes(BaseTestCase):
 
     def test_bulk_upsert_cve_accepts_null_cvss4_fields(self):
         """
-        The CVSS4 import schema must keep accepting explicit JSON nulls
-        anywhere in the nested chain, since some ingestion sources send
-        null rather than omitting these fields.
+        The CVSS4 import schema should keep accepting explicit JSON nulls
+        anywhere in the nested chain. Ingestion sources currently omit
+        these fields rather than sending null, but this is a safety net
+        in case that ever changes.
         """
         response = self.client.put(
             "/security/updates/cves.json",

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -539,13 +539,13 @@ class CvssV4SubsequentSystemImpactMetrics(Schema):
 
 class CvssV4BaseMetrics(Schema):
     exploitabilityMetrics = Nested(
-        CvssV4ExploitabilityMetrics, allow_none=True
+        CvssV4ExploitabilityMetrics
     )
     vulnerableSystemImpactMetrics = Nested(
-        CvssV4VulnerableSystemImpactMetrics, allow_none=True
+        CvssV4VulnerableSystemImpactMetrics
     )
     subsequentSystemImpactMetrics = Nested(
-        CvssV4SubsequentSystemImpactMetrics, allow_none=True
+        CvssV4SubsequentSystemImpactMetrics
     )
 
     class Meta:
@@ -566,13 +566,13 @@ class CvssV4SupplementalMetrics(Schema):
 
 class CvssV4ModifiedBaseMetrics(Schema):
     exploitabilityMetrics = Nested(
-        CvssV4ExploitabilityMetrics, allow_none=True
+        CvssV4ExploitabilityMetrics
     )
     vulnerableSystemImpactMetrics = Nested(
-        CvssV4VulnerableSystemImpactMetrics, allow_none=True
+        CvssV4VulnerableSystemImpactMetrics
     )
     subsequentSystemImpactMetrics = Nested(
-        CvssV4SubsequentSystemImpactMetrics, allow_none=True
+        CvssV4SubsequentSystemImpactMetrics
     )
 
     class Meta:
@@ -589,8 +589,8 @@ class CvssV4SecurityRequirements(Schema):
 
 
 class CvssV4EnvironmentalMetrics(Schema):
-    modifiedBaseMetrics = Nested(CvssV4ModifiedBaseMetrics, allow_none=True)
-    securityRequirements = Nested(CvssV4SecurityRequirements, allow_none=True)
+    modifiedBaseMetrics = Nested(CvssV4ModifiedBaseMetrics)
+    securityRequirements = Nested(CvssV4SecurityRequirements)
 
     class Meta:
         render_module = orjson
@@ -607,10 +607,10 @@ class CvssV4(Schema):
     version = String(allow_none=True)
     vectorString = String(allow_none=True)
 
-    baseMetrics = Nested(CvssV4BaseMetrics, allow_none=True)
-    supplementalMetrics = Nested(CvssV4SupplementalMetrics, allow_none=True)
-    environmentalMetrics = Nested(CvssV4EnvironmentalMetrics, allow_none=True)
-    threatMetrics = Nested(CvssV4ThreatMetrics, allow_none=True)
+    baseMetrics = Nested(CvssV4BaseMetrics)
+    supplementalMetrics = Nested(CvssV4SupplementalMetrics)
+    environmentalMetrics = Nested(CvssV4EnvironmentalMetrics)
+    threatMetrics = Nested(CvssV4ThreatMetrics)
 
     baseScore = Float(allow_none=True)
     baseSeverity = String(allow_none=True)
@@ -629,7 +629,7 @@ class CvssV4(Schema):
 
 
 class CveBaseMetricV4(Schema):
-    cvssV4 = Nested(CvssV4, allow_none=True)
+    cvssV4 = Nested(CvssV4)
 
     class Meta:
         render_module = orjson

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -538,15 +538,9 @@ class CvssV4SubsequentSystemImpactMetrics(Schema):
 
 
 class CvssV4BaseMetrics(Schema):
-    exploitabilityMetrics = Nested(
-        CvssV4ExploitabilityMetrics
-    )
-    vulnerableSystemImpactMetrics = Nested(
-        CvssV4VulnerableSystemImpactMetrics
-    )
-    subsequentSystemImpactMetrics = Nested(
-        CvssV4SubsequentSystemImpactMetrics
-    )
+    exploitabilityMetrics = Nested(CvssV4ExploitabilityMetrics)
+    vulnerableSystemImpactMetrics = Nested(CvssV4VulnerableSystemImpactMetrics)
+    subsequentSystemImpactMetrics = Nested(CvssV4SubsequentSystemImpactMetrics)
 
     class Meta:
         render_module = orjson
@@ -565,15 +559,9 @@ class CvssV4SupplementalMetrics(Schema):
 
 
 class CvssV4ModifiedBaseMetrics(Schema):
-    exploitabilityMetrics = Nested(
-        CvssV4ExploitabilityMetrics
-    )
-    vulnerableSystemImpactMetrics = Nested(
-        CvssV4VulnerableSystemImpactMetrics
-    )
-    subsequentSystemImpactMetrics = Nested(
-        CvssV4SubsequentSystemImpactMetrics
-    )
+    exploitabilityMetrics = Nested(CvssV4ExploitabilityMetrics)
+    vulnerableSystemImpactMetrics = Nested(CvssV4VulnerableSystemImpactMetrics)
+    subsequentSystemImpactMetrics = Nested(CvssV4SubsequentSystemImpactMetrics)
 
     class Meta:
         render_module = orjson

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -546,6 +546,22 @@ class CvssV4BaseMetrics(Schema):
         render_module = orjson
 
 
+# Import variants of the CVSS4 schemas below restore allow_none=True on the
+# Nested fields so the bulk CVE import endpoint keeps accepting explicit
+# JSON nulls, while the non-import versions above stay non-nullable so
+# Swagger UI renders their nested properties correctly.
+class CvssV4BaseMetricsImport(CvssV4BaseMetrics):
+    exploitabilityMetrics = Nested(
+        CvssV4ExploitabilityMetrics, allow_none=True
+    )
+    vulnerableSystemImpactMetrics = Nested(
+        CvssV4VulnerableSystemImpactMetrics, allow_none=True
+    )
+    subsequentSystemImpactMetrics = Nested(
+        CvssV4SubsequentSystemImpactMetrics, allow_none=True
+    )
+
+
 class CvssV4SupplementalMetrics(Schema):
     safety = String(allow_none=True)
     automatable = String(allow_none=True)
@@ -567,6 +583,18 @@ class CvssV4ModifiedBaseMetrics(Schema):
         render_module = orjson
 
 
+class CvssV4ModifiedBaseMetricsImport(CvssV4ModifiedBaseMetrics):
+    exploitabilityMetrics = Nested(
+        CvssV4ExploitabilityMetrics, allow_none=True
+    )
+    vulnerableSystemImpactMetrics = Nested(
+        CvssV4VulnerableSystemImpactMetrics, allow_none=True
+    )
+    subsequentSystemImpactMetrics = Nested(
+        CvssV4SubsequentSystemImpactMetrics, allow_none=True
+    )
+
+
 class CvssV4SecurityRequirements(Schema):
     confidentialityRequirements = String(allow_none=True)
     integrityRequirements = String(allow_none=True)
@@ -582,6 +610,13 @@ class CvssV4EnvironmentalMetrics(Schema):
 
     class Meta:
         render_module = orjson
+
+
+class CvssV4EnvironmentalMetricsImport(CvssV4EnvironmentalMetrics):
+    modifiedBaseMetrics = Nested(
+        CvssV4ModifiedBaseMetricsImport, allow_none=True
+    )
+    securityRequirements = Nested(CvssV4SecurityRequirements, allow_none=True)
 
 
 class CvssV4ThreatMetrics(Schema):
@@ -616,11 +651,24 @@ class CvssV4(Schema):
         render_module = orjson
 
 
+class CvssV4Import(CvssV4):
+    baseMetrics = Nested(CvssV4BaseMetricsImport, allow_none=True)
+    supplementalMetrics = Nested(CvssV4SupplementalMetrics, allow_none=True)
+    environmentalMetrics = Nested(
+        CvssV4EnvironmentalMetricsImport, allow_none=True
+    )
+    threatMetrics = Nested(CvssV4ThreatMetrics, allow_none=True)
+
+
 class CveBaseMetricV4(Schema):
     cvssV4 = Nested(CvssV4)
 
     class Meta:
         render_module = orjson
+
+
+class CveBaseMetricV4Import(CveBaseMetricV4):
+    cvssV4 = Nested(CvssV4Import, allow_none=True)
 
 
 class CveImpact(Schema):
@@ -629,6 +677,10 @@ class CveImpact(Schema):
 
     class Meta:
         render_module = orjson
+
+
+class CveImpactImport(CveImpact):
+    baseMetricV4 = Nested(CveBaseMetricV4Import)
 
 
 class Note(Schema):
@@ -671,6 +723,7 @@ class CVESchema(Schema):
 
 class CVEImportSchema(CVESchema):
     packages = List(Nested(CvePackage))
+    impact = Nested(CveImpactImport)
 
     class Meta:
         render_module = orjson


### PR DESCRIPTION
## Done

- Fixed cvs4 fields not showing up on swagger docs

## QA

- Check out this feature branch
- Run the site using the command `docker compose up -d` then `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8030/security/api/docs#/default/get_security_cves_json
- See that the csv4 fields are documented 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-37123

## Screenshots

<img width="400" height="399" alt="Screenshot 2026-06-11 at 15 19 17" src="https://github.com/user-attachments/assets/1cfc1006-a342-44ec-8bd1-560b77763d55" />
