### PR TITLE
Add indexes on notice_cves / notice_releases join tables to fix query timeouts

### DIFF
--- a/migrations/versions/a1c9f2e4b7d8_add_indexes_for_notice_cves_join.py
+++ b/migrations/versions/a1c9f2e4b7d8_add_indexes_for_notice_cves_join.py
@@ -1,0 +1,57 @@
+"""add indexes for notice_cves / notice_releases join tables
+
+The many-to-many association tables ``notice_cves`` and ``notice_releases``
+were created with foreign key constraints but WITHOUT indexes on their
+columns. PostgreSQL does not create indexes for foreign keys automatically,
+so every query that resolves the CVE<->Notice relationship (selectinload of
+notices for a CVE list, loading the CVEs of a notice, etc.) performed a full
+sequential scan of the join table. As the table grew this pushed those
+queries past ``statement_timeout``, producing 503s on /security/cves.json,
+/security/cves/<id>.json and /security/page/notices.json.
+
+Adding B-tree indexes on both columns of each join table lets PostgreSQL use
+index lookups instead of sequential scans.
+
+Revision ID: a1c9f2e4b7d8
+Revises: b3f1a2c4d5e6
+Create Date: 2026-08-05 00:00:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a1c9f2e4b7d8"
+down_revision = "b3f1a2c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # notice_cves is the CVE <-> Notice association table.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notice_cves_cve_id "
+        "ON notice_cves (cve_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notice_cves_notice_id "
+        "ON notice_cves (notice_id)"
+    )
+
+    # notice_releases is the Release <-> Notice association table and has the
+    # same missing-index problem.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notice_releases_notice_id "
+        "ON notice_releases (notice_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notice_releases_release_codename "
+        "ON notice_releases (release_codename)"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS idx_notice_releases_release_codename")
+    op.execute("DROP INDEX IF EXISTS idx_notice_releases_notice_id")
+    op.execute("DROP INDEX IF EXISTS idx_notice_cves_notice_id")
+    op.execute("DROP INDEX IF EXISTS idx_notice_cves_cve_id")

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -27,19 +27,20 @@ from webapp.types import (
     PRIORITY_OPTIONS,
 )
 
-
 notice_cves = Table(
     "notice_cves",
     db.Model.metadata,
-    Column("notice_id", String, ForeignKey("notice.id")),
-    Column("cve_id", String, ForeignKey("cve.id")),
+    Column("notice_id", String, ForeignKey("notice.id"), index=True),
+    Column("cve_id", String, ForeignKey("cve.id"), index=True),
 )
 
 notice_releases = Table(
     "notice_releases",
     db.Model.metadata,
-    Column("notice_id", String, ForeignKey("notice.id")),
-    Column("release_codename", String, ForeignKey("release.codename")),
+    Column("notice_id", String, ForeignKey("notice.id"), index=True),
+    Column(
+        "release_codename", String, ForeignKey("release.codename"), index=True
+    ),
 )
 
 


### PR DESCRIPTION
## Problem

Production is returning **503s** on `/security/cves.json`, `/security/cves/<id>.json` and `/security/page/notices.json`. Every failing request dies with:

> `psycopg2.errors.QueryCanceled: canceling statement due to statement timeout`

on a query that goes through the **`notice_cves`** join table (the CVE ↔ Notice many-to-many link).

## Root cause

The association tables `notice_cves` and `notice_releases` were created (in `e8760725610a_firstmigration.py`) with foreign-key constraints but **no indexes** on their columns. PostgreSQL does **not** create indexes for foreign keys automatically, so every query resolving the CVE↔Notice / Release↔Notice relationships performs a **sequential scan** of the join table. As these tables have grown, the list endpoints (which fan out to many notices via `selectinload`) now exceed `statement_timeout` and return 503.

Single-CVE lookups mostly stay fast because an earlier migration (`5ad36b3ca4ba`) indexed the `status` table — but the join tables were never covered.

## Fix

- New Alembic migration `a1c9f2e4b7d8` creating B-tree indexes on both columns of each join table:
  - `notice_cves(cve_id)`, `notice_cves(notice_id)`
  - `notice_releases(notice_id)`, `notice_releases(release_codename)`
  - Uses `IF NOT EXISTS` / `IF EXISTS` so upgrade & downgrade are idempotent.
- Add `index=True` to the corresponding `Table` columns in `webapp/models.py` so freshly created databases get the indexes too.

## Safety / rollback

- Adding an index is **non-destructive** — no rows are created or modified.
- Full rollback via `alembic downgrade -1` (drops only these indexes).
- Note: the index build takes a brief write lock on the join tables. If we want to avoid that during deploy, we can switch to `CREATE INDEX CONCURRENTLY` (must run outside a transaction) — happy to do that if preferred.