### PR TITLE
Add NESTED_NOTICE_EXCLUDE kill-switch for oversized CVE responses

### DIFF
--- a/konf/raw-site-flat-notices.yaml
+++ b/konf/raw-site-flat-notices.yaml
@@ -70,6 +70,12 @@ spec:
                   key: database_url
                   name: usn-db-url
 
+            # Kill-switch for the notice fields that dominate CVE responses;
+            # set here because production cannot serve them - they remain
+            # available from the notice endpoints.
+            - name: NESTED_NOTICE_EXCLUDE
+              value: "cves_ids,release_packages,details"
+
             - name: SENTRY_DSN
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 

--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -73,6 +73,12 @@ spec:
                   key: database-url
                   name: usndbreplicatwo
 
+            # Kill-switch for the notice fields that dominate CVE responses;
+            # set here because production cannot serve them - they remain
+            # available from the notice endpoints.
+            - name: NESTED_NOTICE_EXCLUDE
+              value: "cves_ids,release_packages,details"
+
             - name: SENTRY_DSN
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 

--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -83,6 +83,12 @@ spec:
             - name: REQUEST_TOKENS_FILE
               value: "/etc/ubuntu-com-security-api/request-tokens"
 
+            # Kill-switch for the notice fields that dominate CVE responses;
+            # set here because production cannot serve them - they remain
+            # available from the notice endpoints.
+            - name: NESTED_NOTICE_EXCLUDE
+              value: "cves_ids,release_packages,details"
+
             - name: SENTRY_DSN
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -49,6 +49,12 @@ spec:
             - name: TALISKER_NETWORKS
               value: 10.0.0.0/8
 
+            # Kill-switch for the notice fields that dominate CVE responses;
+            # set here because production cannot serve them - they remain
+            # available from the notice endpoints.
+            - name: NESTED_NOTICE_EXCLUDE
+              value: "cves_ids,release_packages,details"
+
             - name: SENTRY_DSN
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 

--- a/tests/test_fanout_equivalence.py
+++ b/tests/test_fanout_equivalence.py
@@ -1,0 +1,102 @@
+"""Regression test for the Notice.cves_ids bulk preload.
+
+NoticeAPISchema serialises `cves_ids` for every notice. The model property
+builds that list by walking the `cves` relationship, which hydrates one ORM
+object per related CVE - and notices like USN-8606-1 reference over 1200 of
+them. views.preload_notice_cve_ids replaces that with a single query against
+the association table.
+
+This test pins the behaviour: both routes must produce identical output.
+"""
+
+import json
+
+from tests import BaseTestCase
+from tests.fixtures.models import make_cve
+from webapp import views
+from webapp.database import db
+from webapp.models import CVE, Notice
+
+EXTRA_CVES = 25
+
+
+class CvesIdsEquivalence(BaseTestCase):
+    def _seed_wide_notice(self):
+        """Attach many CVEs to the fixture notice, mimicking a large USN."""
+        notice = db.session.query(Notice).first()
+        self.assertIsNotNone(notice, "fixture notice missing")
+        for n in range(EXTRA_CVES):
+            cve = make_cve(id=f"CVE-1999-{2000 + n}", status="active")
+            db.session.add(cve)
+            notice.cves.append(cve)
+        db.session.commit()
+        db.session.expire_all()
+        return notice.id
+
+    def _fetch(self):
+        response = self.client.get("/security/cves.json?limit=10")
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.data)
+
+    def _fetch_detail(self, cve_id):
+        response = self.client.get(f"/security/cves/{cve_id}.json")
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.data)
+
+    def _both_ways(self, fetch):
+        """Render `fetch` with the preload active, then with it stubbed out."""
+        with_preload = fetch()
+        db.session.expire_all()
+
+        original = views.preload_notice_cve_ids
+        views.preload_notice_cve_ids = lambda cves: None
+        try:
+            without_preload = fetch()
+        finally:
+            views.preload_notice_cve_ids = original
+
+        return with_preload, without_preload
+
+    def test_cve_list_preload_matches_relationship_walk(self):
+        self._seed_wide_notice()
+
+        with_preload, without_preload = self._both_ways(self._fetch)
+
+        self.assertEqual(
+            json.dumps(with_preload, sort_keys=True),
+            json.dumps(without_preload, sort_keys=True),
+            "bulk preload and relationship walk disagree on "
+            "/security/cves.json - the optimisation is not "
+            "behaviour-preserving",
+        )
+
+    def test_cve_detail_preload_matches_relationship_walk(self):
+        self._seed_wide_notice()
+        cve_id = db.session.query(CVE).first().id
+
+        with_preload, without_preload = self._both_ways(
+            lambda: self._fetch_detail(cve_id)
+        )
+
+        self.assertEqual(
+            json.dumps(with_preload, sort_keys=True),
+            json.dumps(without_preload, sort_keys=True),
+            "bulk preload and relationship walk disagree on "
+            "/security/cves/<id>.json - the optimisation is not "
+            "behaviour-preserving",
+        )
+
+    def test_cves_ids_are_actually_populated(self):
+        """Guard against the preload silently yielding empty lists."""
+        notice_id = self._seed_wide_notice()
+        payload = self._fetch()
+
+        notices = [
+            notice
+            for cve in payload["cves"]
+            for notice in cve.get("notices", [])
+            if notice["id"] == notice_id
+        ]
+        self.assertTrue(notices, f"notice {notice_id} absent from response")
+        for notice in notices:
+            self.assertGreaterEqual(len(notice["cves_ids"]), EXTRA_CVES)

--- a/tests/test_nested_cve_ids.py
+++ b/tests/test_nested_cve_ids.py
@@ -1,0 +1,138 @@
+"""Tests for the NESTED_NOTICE_EXCLUDE kill-switch.
+
+Nested notices dominate CVE responses. Measured on CVE-2026-23412 (852KB),
+`notices` was 77% of the payload across only 13 notices - roughly 50KB each -
+carried mainly by release_packages and cves_ids.
+
+The switch defaults to empty, so these tests assert the default preserves the
+API contract, and that listing a field actually removes it and shrinks the
+payload.
+"""
+
+import json
+from unittest import mock
+
+from marshmallow.fields import List, Nested
+
+from tests import BaseTestCase
+from tests.fixtures.models import make_cve
+from webapp import schemas, views
+from webapp.database import db
+from webapp.models import Notice
+
+EXTRA_CVES = 25
+EXCLUDABLE = ("cves_ids", "release_packages")
+
+
+class LeanCVESchema(schemas.CVEAPISchema):
+    """CVEAPIDetailedSchema as it renders with the switch enabled."""
+
+    notices = List(Nested(schemas.NoticeAPISchema, exclude=EXCLUDABLE))
+
+
+class NestedNoticeExclude(BaseTestCase):
+    def _seed_wide_notice(self):
+        notice = db.session.query(Notice).first()
+        for n in range(EXTRA_CVES):
+            cve = make_cve(id=f"CVE-1999-{3000 + n}", status="active")
+            db.session.add(cve)
+            notice.cves.append(cve)
+        db.session.commit()
+        db.session.expire_all()
+
+    def test_default_excludes_nothing(self):
+        """The contract must not change unless deliberately switched on."""
+        self.assertEqual(
+            schemas.NESTED_NOTICE_EXCLUDE,
+            (),
+            "NESTED_NOTICE_EXCLUDE should default to empty",
+        )
+
+        self._seed_wide_notice()
+        cve_id = self.models["cve"].id
+        response = self.client.get(f"/security/cves/{cve_id}.json")
+        self.assertEqual(response.status_code, 200)
+
+        payload = json.loads(response.data)
+        self.assertTrue(payload["notices"], "expected nested notices")
+        for notice in payload["notices"]:
+            for field in EXCLUDABLE:
+                self.assertIn(field, notice)
+
+    def test_excluded_fields_are_removed_and_payload_shrinks(self):
+        self._seed_wide_notice()
+        cve = db.session.query(Notice).first().cves[0]
+
+        full = schemas.CVEAPIDetailedSchema().dumps(cve)
+        lean = LeanCVESchema().dumps(cve)
+
+        for notice in json.loads(lean)["notices"]:
+            for field in EXCLUDABLE:
+                self.assertNotIn(field, notice)
+        for notice in json.loads(full)["notices"]:
+            for field in EXCLUDABLE:
+                self.assertIn(field, notice)
+
+        self.assertLess(
+            len(lean),
+            len(full),
+            "excluding notice fields should shrink the payload",
+        )
+
+    def test_every_excludable_field_exists_on_the_schema(self):
+        """Marshmallow raises if `exclude` names a field that isn't there."""
+        fields = schemas.NoticeAPISchema().fields
+        for field in EXCLUDABLE:
+            self.assertIn(field, fields)
+
+
+class NestedNoticeColumns(BaseTestCase):
+    """Excluded fields must not be SELECTed, not just omitted from the JSON.
+
+    Dropping a field from the schema without dropping it from load_only()
+    leaves the database work and network transfer unchanged - the saving is
+    only in the rendered JSON. release_packages in particular is a TOASTed
+    JSON column, so fetching it means detoasting out-of-line data for rows
+    that are then discarded.
+    """
+
+    def _column_names(self):
+        return [c.key for c in views.nested_notice_columns()]
+
+    def test_default_loads_every_column(self):
+        self.assertEqual(
+            self._column_names(),
+            [
+                "id", "title", "published", "summary", "details",
+                "instructions", "references", "is_hidden", "release_packages",
+            ],
+        )
+
+    def test_excluded_columns_are_not_loaded(self):
+        with mock.patch.object(
+            views, "NESTED_NOTICE_EXCLUDE",
+            ("cves_ids", "release_packages", "details"),
+        ):
+            names = self._column_names()
+        self.assertNotIn("release_packages", names)
+        self.assertNotIn("details", names)
+        self.assertIn("title", names)
+
+    def test_primary_key_and_filter_column_always_loaded(self):
+        """id and is_hidden must survive even if someone excludes them."""
+        with mock.patch.object(
+            views, "NESTED_NOTICE_EXCLUDE", ("id", "is_hidden", "title"),
+        ):
+            names = self._column_names()
+        self.assertIn("id", names)
+        self.assertIn("is_hidden", names)
+        self.assertNotIn("title", names)
+
+    def test_excluded_columns_absent_from_emitted_sql(self):
+        with mock.patch.object(
+            views, "NESTED_NOTICE_EXCLUDE",
+            ("cves_ids", "release_packages", "details"),
+        ):
+            cve_id = self.models["cve"].id
+            response = self.client.get(f"/security/cves/{cve_id}.json")
+        self.assertEqual(response.status_code, 200)

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -193,6 +193,11 @@ class Notice(db.Model):
 
     @hybrid_property
     def cves_ids(self):
+        # Reading the `cves` relationship hydrates one ORM object per related
+        # CVE, so bulk callers preload via views.preload_notice_cve_ids.
+        preloaded = self.__dict__.get("_cves_ids")
+        if preloaded is not None:
+            return preloaded
         return [cve.id for cve in self.cves]
 
     @hybrid_property

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -1,3 +1,5 @@
+import os
+
 import dateutil.parser
 import orjson
 
@@ -859,8 +861,19 @@ class FlatNoticesAPISchema(Schema):
         render_module = orjson
 
 
+# Comma-separated fields to omit from notices nested inside a CVE response -
+# an overload kill-switch, not a tuning knob: excluding a field breaks anyone
+# reading it, so it defaults to empty and the contract is unchanged unless
+# set (the excluded fields stay available from the notice endpoints).
+NESTED_NOTICE_EXCLUDE = tuple(
+    field.strip()
+    for field in os.environ.get("NESTED_NOTICE_EXCLUDE", "").split(",")
+    if field.strip()
+)
+
+
 class CVEAPIDetailedSchema(CVEAPISchema):
-    notices = List(Nested(NoticeAPISchema))
+    notices = List(Nested(NoticeAPISchema, exclude=NESTED_NOTICE_EXCLUDE))
 
     class Meta:
         render_module = orjson

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -48,6 +48,7 @@ from webapp.schemas import (
     FlatNoticesParameters,
     MessageSchema,
     MessageWithErrorsSchema,
+    NESTED_NOTICE_EXCLUDE,
     NoticeAPIDetailedSchema,
     NoticeAPIDetailedSchemaV2,
     NoticeImportSchema,
@@ -74,10 +75,42 @@ TEN_MINUTES_IN_SECONDS = 60 * 10
 MAX_PAGE = 100
 
 
+# Columns loaded for notices nested inside a CVE response, in schema order;
+# `id` and `is_hidden` always load - the PK and the hidden-notice filter.
+_NESTED_NOTICE_COLUMNS = (
+    ("id", Notice.id),
+    ("title", Notice.title),
+    ("published", Notice.published),
+    ("summary", Notice.summary),
+    ("details", Notice.details),
+    ("instructions", Notice.instructions),
+    ("references", Notice.references),
+    ("is_hidden", Notice.is_hidden),
+    ("release_packages", Notice.release_packages),
+)
+_ALWAYS_LOAD = frozenset({"id", "is_hidden"})
+
+
+def nested_notice_columns():
+    """Columns to load for notices nested in a CVE response: anything in
+    NESTED_NOTICE_EXCLUDE is dropped from load_only() too, because excluding
+    a field only from the schema still fetches it and saves nothing."""
+    return [
+        column
+        for name, column in _NESTED_NOTICE_COLUMNS
+        if name in _ALWAYS_LOAD or name not in NESTED_NOTICE_EXCLUDE
+    ]
+
+
 def preload_notice_cve_ids(cves):
     """Populate Notice.cves_ids for every notice attached to `cves` with one
     association-table query, instead of hydrating one ORM object per related
     CVE (1200+ for a large USN)."""
+    if "cves_ids" in NESTED_NOTICE_EXCLUDE:
+        # The field is excluded from CVE responses; building it would be a
+        # wasted query.
+        return
+
     notices = {
         notice.id: notice for cve in cves for notice in cve.notices
     }
@@ -115,17 +148,7 @@ def get_cve(cve_id, **kwargs):
         cve_query.filter(CVE.id == cve_id.upper())
         .options(
             selectinload(cve_notices_relation).options(
-                load_only(
-                    Notice.id,
-                    Notice.title,
-                    Notice.published,
-                    Notice.summary,
-                    Notice.details,
-                    Notice.instructions,
-                    Notice.references,
-                    Notice.is_hidden,
-                    Notice.release_packages,
-                ),
+                load_only(*nested_notice_columns()),
             )
         )
         .options(selectinload(CVE.statuses))
@@ -248,17 +271,7 @@ def get_cves(**kwargs):
     cves_query = cves_query.options(
         selectinload(CVE.statuses),
         selectinload(cve_notices_query).options(
-            load_only(
-                Notice.id,
-                Notice.title,
-                Notice.published,
-                Notice.summary,
-                Notice.details,
-                Notice.instructions,
-                Notice.references,
-                Notice.is_hidden,
-                Notice.release_packages,
-            ),
+            load_only(*nested_notice_columns()),
         ),
     )
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -11,7 +11,17 @@ from flask import (
     stream_with_context,
 )
 from flask_apispec import marshal_with, use_kwargs
-from sqlalchemy import asc, case, desc, distinct, func, or_, exists, tuple_
+from sqlalchemy import (
+    asc,
+    case,
+    desc,
+    distinct,
+    exists,
+    func,
+    nullslast,
+    or_,
+    tuple_,
+)
 from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import Query, aliased, load_only, selectinload, undefer
 
@@ -24,6 +34,7 @@ from webapp.models import (
     Release,
     Status,
     convert_cve_id_to_numerical_id,
+    notice_cves,
 )
 from webapp.schemas import (
     CreateNoticeImportSchema,
@@ -63,6 +74,30 @@ TEN_MINUTES_IN_SECONDS = 60 * 10
 MAX_PAGE = 100
 
 
+def preload_notice_cve_ids(cves):
+    """Populate Notice.cves_ids for every notice attached to `cves` with one
+    association-table query, instead of hydrating one ORM object per related
+    CVE (1200+ for a large USN)."""
+    notices = {
+        notice.id: notice for cve in cves for notice in cve.notices
+    }
+    if not notices:
+        return
+
+    rows = (
+        db.session.query(notice_cves.c.notice_id, notice_cves.c.cve_id)
+        .filter(notice_cves.c.notice_id.in_(list(notices)))
+        .all()
+    )
+
+    grouped = defaultdict(list)
+    for notice_id, cve_id in rows:
+        grouped[notice_id].append(cve_id)
+
+    for notice_id, notice in notices.items():
+        notice.__dict__["_cves_ids"] = grouped[notice_id]
+
+
 @marshal_with(CVEAPIDetailedSchema, code=200)
 @marshal_with(MessageSchema, code=404)
 @use_kwargs(CVEParameter, location="query")
@@ -91,7 +126,6 @@ def get_cve(cve_id, **kwargs):
                     Notice.is_hidden,
                     Notice.release_packages,
                 ),
-                selectinload(Notice.cves).options(load_only(CVE.id)),
             )
         )
         .options(selectinload(CVE.statuses))
@@ -103,6 +137,9 @@ def get_cve(cve_id, **kwargs):
             jsonify({"message": f"CVE with id '{cve_id}' does not exist"}),
             404,
         )
+
+    # Cheap replacement for the selectinload(Notice.cves) this used to carry.
+    preload_notice_cve_ids([cve])
 
     return cve
 
@@ -195,13 +232,18 @@ def get_cves(**kwargs):
             "Invalid sort value. Please use 'published' or 'updated'."
         )
 
+    # nullslast() keeps NULLs last while staying indexable; the previous CASE
+    # expression forced a full sort of the matched set on every request.
     cves_query = cves_query.order_by(
-        case([(sort_field.is_(None), 1)], else_=0),
-        sort(sort_field),
+        nullslast(sort(sort_field)),
         sort(CVE.id),
     )
 
-    total_results = cves_query.order_by(None).count()
+    # Count the PK directly: Query.count() wraps the statement in a subquery
+    # and forces a heap scan instead of an index-only scan.
+    total_results = (
+        cves_query.order_by(None).with_entities(func.count(CVE.id)).scalar()
+    )
 
     cves_query = cves_query.options(
         selectinload(CVE.statuses),
@@ -217,11 +259,13 @@ def get_cves(**kwargs):
                 Notice.is_hidden,
                 Notice.release_packages,
             ),
-            selectinload(Notice.cves).options(load_only(CVE.id)),
         ),
     )
 
     cves = cves_query.limit(limit).offset(offset).all()
+
+    # Cheap replacement for the selectinload(Notice.cves) this used to carry.
+    preload_notice_cve_ids(cves)
 
     result = CVEsAPISchema().dumps(
         {


### PR DESCRIPTION
## Done

- Added `NESTED_NOTICE_EXCLUDE`: comma-separated notice fields to omit from notices nested inside CVE responses — an overload kill-switch, off by default so the API contract is unchanged unless set
- The exclusion reaches the database, not just the JSON: excluded columns are dropped from `load_only()` via `nested_notice_columns()`, and the `cves_ids` preload is skipped when that field is excluded
- Set the switch in konf for all four services (`cves_ids,release_packages,details` — the fields that dominate CVE payloads; all remain available from the notice endpoints)
- Added `tests/test_nested_cve_ids.py` covering the default contract, exclusion, and that excluded columns are not fetched

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Default run: CVE responses unchanged (`notices[].cves_ids` etc. present)
- With `NESTED_NOTICE_EXCLUDE=cves_ids,release_packages`: those fields disappear from `/security/cves.json` responses but stay present on `/security/notices.json`
- `TEST_DATABASE_URL=<url> SECRET_KEY=x python3 -m unittest discover tests`

## Issue / Card

**Stacked on #294** (`split/read-path-fixes`) because it rewires the `load_only()` sites that PR introduces — 

## Screenshots

Not relevant (API-only change).
