### PR TITLE
Size pods to measured usage and make probes tolerate saturation

### DIFF
--- a/konf/raw-site-flat-notices.yaml
+++ b/konf/raw-site-flat-notices.yaml
@@ -88,8 +88,7 @@ spec:
             requests:
               ephemeral-storage: 128Mi
               memory: 512Mi
-              # A CPU request stops these pods being best-effort under node
-              # contention; deliberately no limit, which throttles bursts.
+              # CPU request without a limit: avoids best-effort scheduling but lets bursts through.
               cpu: 500m
             limits:
               ephemeral-storage: 1Gi

--- a/konf/raw-site-flat-notices.yaml
+++ b/konf/raw-site-flat-notices.yaml
@@ -73,16 +73,24 @@ spec:
             - name: SENTRY_DSN
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 
+          # /_status/check touches no database but still needs a free gunicorn
+          # worker, so these values tolerate transient starvation instead of
+          # ejecting a busy-but-healthy pod (rationale in raw-site.yaml).
           readinessProbe:
             httpGet:
               path: /_status/check
               port: 80
-            periodSeconds: 5
-            timeoutSeconds: 3
+            periodSeconds: 15
+            timeoutSeconds: 15
+            failureThreshold: 5
 
           resources:
             requests:
               ephemeral-storage: 128Mi
+              memory: 512Mi
+              # A CPU request stops these pods being best-effort under node
+              # contention; deliberately no limit, which throttles bursts.
+              cpu: 500m
             limits:
               ephemeral-storage: 1Gi
               memory: 2G

--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -76,17 +76,24 @@ spec:
             - name: SENTRY_DSN
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 
+          # /_status/check touches no database but still needs a free gunicorn
+          # worker, so these values tolerate transient starvation instead of
+          # ejecting a busy-but-healthy pod (rationale in raw-site.yaml).
           readinessProbe:
             httpGet:
               path: /_status/check
               port: 80
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 15
+            timeoutSeconds: 15
+            failureThreshold: 5
 
           resources:
             requests:
               ephemeral-storage: 128Mi
+              memory: 512Mi
+              # A CPU request stops these pods being best-effort under node
+              # contention; deliberately no limit, which throttles bursts.
+              cpu: 500m
             limits:
               ephemeral-storage: 1Gi
               memory: 2G

--- a/konf/raw-site-notices.yaml
+++ b/konf/raw-site-notices.yaml
@@ -91,8 +91,7 @@ spec:
             requests:
               ephemeral-storage: 128Mi
               memory: 512Mi
-              # A CPU request stops these pods being best-effort under node
-              # contention; deliberately no limit, which throttles bursts.
+              # CPU request without a limit: avoids best-effort scheduling but lets bursts through.
               cpu: 500m
             limits:
               ephemeral-storage: 1Gi

--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -86,16 +86,25 @@ spec:
             - name: SENTRY_DSN
               value: "https://88233b54cb8e9f8d8df4ace2349e0b8b@o4510662863749120.ingest.de.sentry.io/4511652407345232"
 
+          # /_status/check touches no database but still needs a free gunicorn
+          # worker, so these values tolerate transient starvation instead of
+          # ejecting a busy-but-healthy pod (rationale in raw-site.yaml).
           readinessProbe:
             httpGet:
               path: /_status/check
               port: 80
-            periodSeconds: 5
-            timeoutSeconds: 3
+            periodSeconds: 15
+            timeoutSeconds: 15
+            failureThreshold: 5
 
           resources:
+            requests:
+              memory: 512Mi
+              # A CPU request stops these pods being best-effort under node
+              # contention; deliberately no limit, which throttles bursts.
+              cpu: 500m
             limits:
-              memory: 1G
+              memory: 2G
 
           volumeMounts:
           - mountPath: /etc/ubuntu-com-security-api/

--- a/konf/raw-site-updates.yaml
+++ b/konf/raw-site-updates.yaml
@@ -100,8 +100,7 @@ spec:
           resources:
             requests:
               memory: 512Mi
-              # A CPU request stops these pods being best-effort under node
-              # contention; deliberately no limit, which throttles bursts.
+              # CPU request without a limit: avoids best-effort scheduling but lets bursts through.
               cpu: 500m
             limits:
               memory: 2G

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -76,17 +76,28 @@ spec:
                   key: database-url
                   name: usndbreplica
 
+          # /_status/check touches no database but still needs a free gunicorn
+          # worker, so these values tolerate transient starvation instead of
+          # ejecting a busy-but-healthy pod (the 503s nginx surfaced).
           readinessProbe:
             httpGet:
               path: /_status/check
               port: 80
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 15
+            timeoutSeconds: 15
+            failureThreshold: 5
 
           resources:
             requests:
               ephemeral-storage: 128Mi
+              # Observed steady state is 260-510Mi per pod.
+              memory: 512Mi
+              # A CPU request stops these pods being best-effort under node
+              # contention (observed 47-762m); deliberately no limit, which
+              # throttles bursts.
+              cpu: 500m
             limits:
               ephemeral-storage: 1Gi
-              memory: 1G
+              # Raised from 1G after an OOMKill under concurrent large
+              # responses; 2G is ~4x the observed peak.
+              memory: 2G

--- a/konf/raw-site.yaml
+++ b/konf/raw-site.yaml
@@ -92,9 +92,7 @@ spec:
               ephemeral-storage: 128Mi
               # Observed steady state is 260-510Mi per pod.
               memory: 512Mi
-              # A CPU request stops these pods being best-effort under node
-              # contention (observed 47-762m); deliberately no limit, which
-              # throttles bursts.
+              # CPU request without a limit: avoids best-effort scheduling but lets bursts through (observed 47-762m).
               cpu: 500m
             limits:
               ephemeral-storage: 1Gi


### PR DESCRIPTION
/_status/check hits no database, but it still needs a free gunicorn worker to respond. With only 5 workers, a burst of slow CVE queries leaves the probe queued behind them, so it times out at 3s even though the pod is healthy and working normally.

That failure cascades. Readiness failures don't restart the pod, they pull it out of the load balancer. The busiest pod drops out, its traffic shifts to the remaining pods, those get busier and start failing their own probes, and so on until nginx has no healthy backend and serves 503s.

## Done

- Readiness probes now tolerate transient worker starvation (15s period, 15s timeout, 5 failures) instead of ejecting a busy-but-healthy pod — probe starvation is what nginx surfaced as 503s for every consumer
- Memory requests set to observed steady state (260–510Mi → request 512Mi); limit raised to 2G after an OOMKill under concurrent large responses
- CPU requests (500m) added so the pods are no longer best-effort under node contention; deliberately no CPU limit, which throttles bursts
- Applied to all four services

## QA

- Config-only change: `./run serve` behaviour is unaffected
- Review the konf diffs
- After deploy: `kubectl get pods` should show no readiness flapping under load, and `kubectl top pods` staying within requests

## Issue / Card

Part of the `/security/cves.json` outage remediation

## Screenshots

Not relevant (deployment config).
