### PR TITLE
Harden database layer: real error responses, pool sizing, connection timeouts

### DIFF
--- a/tests/test_db_error_handler.py
+++ b/tests/test_db_error_handler.py
@@ -1,0 +1,55 @@
+"""The SQLAlchemy error handlers must return a response, not None.
+
+Returning None makes Flask raise:
+
+    TypeError: The view function for '<view>' did not return a valid
+    response. The function either returned None or ended without a return
+    statement.
+
+which blames the view and hides the database error that actually happened.
+This matters routinely now that the read engines carry a statement_timeout -
+Postgres cancelling a slow query raises OperationalError, which is a
+SQLAlchemyError, so this path is reached under load rather than only in
+exceptional cases.
+"""
+
+from unittest import mock
+
+from sqlalchemy import exc
+
+from tests import BaseTestCase
+
+
+class DatabaseErrorHandler(BaseTestCase):
+    def test_sqlalchemy_error_returns_503_not_none(self):
+        cve_id = self.models["cve"].id
+        boom = exc.OperationalError(
+            "SELECT 1", {}, Exception("canceling statement due to timeout")
+        )
+
+        with mock.patch(
+            "webapp.views.db.session.query", side_effect=boom
+        ):
+            response = self.client.get(f"/security/cves/{cve_id}.json")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.headers.get("Retry-After"), "5")
+        self.assertIn(
+            "temporarily unavailable", response.get_json()["message"]
+        )
+
+    def test_pending_rollback_error_returns_503_not_none(self):
+        cve_id = self.models["cve"].id
+        boom = exc.PendingRollbackError("rollback required", None, None)
+
+        with mock.patch(
+            "webapp.views.db.session.query", side_effect=boom
+        ):
+            response = self.client.get(f"/security/cves/{cve_id}.json")
+
+        self.assertEqual(response.status_code, 503)
+
+    def test_normal_requests_are_unaffected(self):
+        cve_id = self.models["cve"].id
+        response = self.client.get(f"/security/cves/{cve_id}.json")
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_db_error_handler.py
+++ b/tests/test_db_error_handler.py
@@ -23,9 +23,7 @@ class DatabaseErrorHandler(BaseTestCase):
             "SELECT 1", {}, Exception("canceling statement due to timeout")
         )
 
-        with mock.patch(
-            "webapp.views.db.session.query", side_effect=boom
-        ):
+        with mock.patch("webapp.views.db.session.query", side_effect=boom):
             response = self.client.get(f"/security/cves/{cve_id}.json")
 
         self.assertEqual(response.status_code, 503)
@@ -38,9 +36,7 @@ class DatabaseErrorHandler(BaseTestCase):
         cve_id = self.models["cve"].id
         boom = exc.PendingRollbackError("rollback required", None, None)
 
-        with mock.patch(
-            "webapp.views.db.session.query", side_effect=boom
-        ):
+        with mock.patch("webapp.views.db.session.query", side_effect=boom):
             response = self.client.get(f"/security/cves/{cve_id}.json")
 
         self.assertEqual(response.status_code, 503)
@@ -52,9 +48,7 @@ class DatabaseErrorHandler(BaseTestCase):
             "SELECT 1", {}, Exception('column "nope" does not exist')
         )
 
-        with mock.patch(
-            "webapp.views.db.session.query", side_effect=boom
-        ):
+        with mock.patch("webapp.views.db.session.query", side_effect=boom):
             response = self.client.get(f"/security/cves/{cve_id}.json")
 
         self.assertEqual(response.status_code, 500)
@@ -67,9 +61,7 @@ class DatabaseErrorHandler(BaseTestCase):
             "INSERT", {}, Exception("violates foreign key constraint")
         )
 
-        with mock.patch(
-            "webapp.views.db.session.query", side_effect=boom
-        ):
+        with mock.patch("webapp.views.db.session.query", side_effect=boom):
             response = self.client.get(f"/security/cves/{cve_id}.json")
 
         self.assertEqual(response.status_code, 500)

--- a/tests/test_db_error_handler.py
+++ b/tests/test_db_error_handler.py
@@ -1,22 +1,12 @@
 """The SQLAlchemy error handlers must return a response, not None.
 
-Returning None makes Flask raise:
+Returning None makes Flask raise a TypeError blaming the view, which hides
+the database error. The read engines carry a statement_timeout, so Postgres
+cancelling a slow query reaches this path under load, not just in edge cases.
 
-    TypeError: The view function for '<view>' did not return a valid
-    response. The function either returned None or ended without a return
-    statement.
-
-which blames the view and hides the database error that actually happened.
-This matters routinely now that the read engines carry a statement_timeout -
-Postgres cancelling a slow query raises OperationalError, which is a
-SQLAlchemyError, so this path is reached under load rather than only in
-exceptional cases.
-
-The handlers also have to distinguish transient failures from permanent ones.
-A 503 with Retry-After tells a client to come back, which is right for a lost
-connection and wrong for schema drift or a constraint violation: the CVE
-importer retries, and pointing it at a failure that cannot clear produces a
-loop that never terminates.
+The handlers must also separate transient failures from permanent ones. A 503
+with Retry-After is right for a lost connection and wrong for schema drift:
+the CVE importer retries, so a failure that cannot clear becomes a loop.
 """
 
 from unittest import mock

--- a/tests/test_db_error_handler.py
+++ b/tests/test_db_error_handler.py
@@ -11,6 +11,12 @@ This matters routinely now that the read engines carry a statement_timeout -
 Postgres cancelling a slow query raises OperationalError, which is a
 SQLAlchemyError, so this path is reached under load rather than only in
 exceptional cases.
+
+The handlers also have to distinguish transient failures from permanent ones.
+A 503 with Retry-After tells a client to come back, which is right for a lost
+connection and wrong for schema drift or a constraint violation: the CVE
+importer retries, and pointing it at a failure that cannot clear produces a
+loop that never terminates.
 """
 
 from unittest import mock
@@ -48,6 +54,36 @@ class DatabaseErrorHandler(BaseTestCase):
             response = self.client.get(f"/security/cves/{cve_id}.json")
 
         self.assertEqual(response.status_code, 503)
+
+    def test_programming_error_is_not_advertised_as_retryable(self):
+        """Schema drift is permanent: 500, and no Retry-After."""
+        cve_id = self.models["cve"].id
+        boom = exc.ProgrammingError(
+            "SELECT 1", {}, Exception('column "nope" does not exist')
+        )
+
+        with mock.patch(
+            "webapp.views.db.session.query", side_effect=boom
+        ):
+            response = self.client.get(f"/security/cves/{cve_id}.json")
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIsNone(response.headers.get("Retry-After"))
+
+    def test_integrity_error_is_not_advertised_as_retryable(self):
+        """A constraint violation will not clear on retry either."""
+        cve_id = self.models["cve"].id
+        boom = exc.IntegrityError(
+            "INSERT", {}, Exception("violates foreign key constraint")
+        )
+
+        with mock.patch(
+            "webapp.views.db.session.query", side_effect=boom
+        ):
+            response = self.client.get(f"/security/cves/{cve_id}.json")
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIsNone(response.headers.get("Retry-After"))
 
     def test_normal_requests_are_unaffected(self):
         cve_id = self.models["cve"].id

--- a/tests/test_db_error_handler.py
+++ b/tests/test_db_error_handler.py
@@ -1,12 +1,8 @@
-"""The SQLAlchemy error handlers must return a response, not None.
+"""Database error handlers must return a response, and only advertise
+Retry-After for failures a retry can clear.
 
-Returning None makes Flask raise a TypeError blaming the view, which hides
-the database error. Dropped connections and replica recovery conflicts reach
-this path under load, not just in edge cases.
-
-The handlers must also separate transient failures from permanent ones. A 503
-with Retry-After is right for a lost connection and wrong for schema drift:
-the CVE importer retries, so a failure that cannot clear becomes a loop.
+Returning None makes Flask raise a TypeError that hides the real error. A
+Retry-After on schema drift makes the retrying CVE importer loop forever.
 """
 
 from unittest import mock

--- a/tests/test_db_error_handler.py
+++ b/tests/test_db_error_handler.py
@@ -1,8 +1,8 @@
 """The SQLAlchemy error handlers must return a response, not None.
 
 Returning None makes Flask raise a TypeError blaming the view, which hides
-the database error. The read engines carry a statement_timeout, so Postgres
-cancelling a slow query reaches this path under load, not just in edge cases.
+the database error. Dropped connections and replica recovery conflicts reach
+this path under load, not just in edge cases.
 
 The handlers must also separate transient failures from permanent ones. A 503
 with Retry-After is right for a lost connection and wrong for schema drift:
@@ -20,7 +20,9 @@ class DatabaseErrorHandler(BaseTestCase):
     def test_sqlalchemy_error_returns_503_not_none(self):
         cve_id = self.models["cve"].id
         boom = exc.OperationalError(
-            "SELECT 1", {}, Exception("canceling statement due to timeout")
+            "SELECT 1",
+            {},
+            Exception("SSL connection has been closed unexpectedly"),
         )
 
         with mock.patch("webapp.views.db.session.query", side_effect=boom):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -125,6 +125,9 @@ if sentry_dsn and environment == "production":
         send_default_pii=False,
         environment=environment,
         integrations=[FlaskIntegration()],
+        # View locals hold hydrated ORM graphs; serialising them on worker
+        # aborts burns CPU and buries the real exception in serializer noise.
+        include_local_variables=False,
     )
 
 init_db(app)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -125,8 +125,7 @@ if sentry_dsn and environment == "production":
         send_default_pii=False,
         environment=environment,
         integrations=[FlaskIntegration()],
-        # View locals hold hydrated ORM graphs: serialising them on aborts
-        # burns CPU and buries the real exception.
+        # Serialising ORM objects in view locals breaks Sentry's reporter.
         include_local_variables=False,
     )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -125,8 +125,8 @@ if sentry_dsn and environment == "production":
         send_default_pii=False,
         environment=environment,
         integrations=[FlaskIntegration()],
-        # View locals hold hydrated ORM graphs; serialising them on worker
-        # aborts burns CPU and buries the real exception in serializer noise.
+        # View locals hold hydrated ORM graphs: serialising them on aborts
+        # burns CPU and buries the real exception.
         include_local_variables=False,
     )
 

--- a/webapp/auth.py
+++ b/webapp/auth.py
@@ -306,8 +306,10 @@ def oauth_authorization_required(func: Callable) -> Callable:
                     oauth_token,
                     oauth_token_secret,
                 ):
-                    logger.info("""[AUTHWORKER] User is authorized,
-                          proceeding with request""")
+                    logger.info(
+                        """[AUTHWORKER] User is authorized,
+                          proceeding with request"""
+                    )
                     # Save the access token for future use
                     save_access_token(token, access_token)
 

--- a/webapp/auth.py
+++ b/webapp/auth.py
@@ -21,7 +21,6 @@ from macaroonbakery import bakery, checkers, httpbakery
 from canonicalwebteam.flask_base.env import get_flask_env
 from requests_oauthlib import OAuth1Session
 
-
 logger = logging.getLogger()
 logger.addHandler(default_handler)
 
@@ -307,10 +306,8 @@ def oauth_authorization_required(func: Callable) -> Callable:
                     oauth_token,
                     oauth_token_secret,
                 ):
-                    logger.info(
-                        """[AUTHWORKER] User is authorized,
-                          proceeding with request"""
-                    )
+                    logger.info("""[AUTHWORKER] User is authorized,
+                          proceeding with request""")
                     # Save the access token for future use
                     save_access_token(token, access_token)
 

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -26,6 +26,7 @@ both `app.py` and `models.py`, and then inside `app.py` we do:
 To add the application context
 """
 
+from flask import jsonify, make_response
 from flask_migrate import Migrate
 from canonicalwebteam.flask_base.env import get_flask_env
 from flask_sqlalchemy import SQLAlchemy
@@ -47,24 +48,68 @@ REPLICA_TWO_DATABASE_URL = get_flask_env(
     PRIMARY_DATABASE_URL,
 )
 
+# connect_timeout bounds the handshake against a failed-over host that never
+# completes one; keepalives let the server reap backends stranded by
+# SIGKILLed workers.
+BASE_CONNECT_ARGS = {
+    "connect_timeout": 5,
+    "keepalives": 1,
+    "keepalives_idle": 30,
+    "keepalives_interval": 10,
+    "keepalives_count": 3,
+}
+
+# Server-side backstop for stranded backends; both values sit above
+# gunicorn's --timeout so only abandoned transactions are aborted (a CLI
+# import idling >5min mid-transaction will be too - raise PRIMARY_PG_OPTIONS).
+READ_PG_OPTIONS = (
+    "-c statement_timeout=10000 -c idle_in_transaction_session_timeout=60000"
+)
+PRIMARY_PG_OPTIONS = "-c idle_in_transaction_session_timeout=300000"
+
+# Sized against the server: max_connections is 100 and the fleet is 18 pods
+# x 5 workers = 90 processes, so pool_size 1 is the floor and cannot absorb
+# another worker increase. pool_timeout is short so an exhausted pool fails
+# fast instead of blocking into gunicorn's worker-timeout cascade.
 SQLALCHEMY_ENGINE_OPTIONS = {
     "pool_recycle": 3600,
     "pool_pre_ping": True,
+    "pool_size": 1,
+    "max_overflow": 2,
+    "pool_timeout": 5,
+    "connect_args": {**BASE_CONNECT_ARGS, "options": PRIMARY_PG_OPTIONS},
+}
+
+# Reads are aborted by the database at 10s so a slow query frees its worker
+# and connection; the primary deliberately has no statement_timeout because
+# bulk CVE imports legitimately run long.
+READ_ENGINE_OPTIONS = {
+    **SQLALCHEMY_ENGINE_OPTIONS,
+    "connect_args": {**BASE_CONNECT_ARGS, "options": READ_PG_OPTIONS},
 }
 
 # Bind names
 REPLICA_ONE = "replicaone"
 REPLICA_TWO = "replicatwo"
 
-engines = {
-    REPLICA_ONE: create_engine(
-        url=REPLICA_ONE_DATABASE_URL,
-        **SQLALCHEMY_ENGINE_OPTIONS,
-    ),
-    REPLICA_TWO: create_engine(
+_replica_one_engine = create_engine(
+    url=REPLICA_ONE_DATABASE_URL,
+    **READ_ENGINE_OPTIONS,
+)
+
+# The replica URLs fall back to DATABASE_URL when unset, so share one engine
+# while they match rather than doubling the connection count for one server.
+if REPLICA_TWO_DATABASE_URL == REPLICA_ONE_DATABASE_URL:
+    _replica_two_engine = _replica_one_engine
+else:
+    _replica_two_engine = create_engine(
         url=REPLICA_TWO_DATABASE_URL,
-        **SQLALCHEMY_ENGINE_OPTIONS,
-    ),
+        **READ_ENGINE_OPTIONS,
+    )
+
+engines = {
+    REPLICA_ONE: _replica_one_engine,
+    REPLICA_TWO: _replica_two_engine,
 }
 
 primary_engine = create_engine(
@@ -109,13 +154,24 @@ def init_db(app):
     db.init_app(app)
     Migrate(app, db)
 
-    @app.errorhandler(exc.PendingRollbackError)
-    def handle_db_exceptions(error):
-        # log the error:
+    # These handlers must return a response: returning None makes Flask
+    # raise a TypeError blaming the view, hiding the actual database error.
+    def _database_unavailable(error):
         app.logger.error(error)
         db.session.rollback()
+        response = make_response(
+            jsonify(
+                {
+                    "message": (
+                        "The database is temporarily unavailable. "
+                        "Please retry shortly."
+                    )
+                }
+            ),
+            503,
+        )
+        response.headers["Retry-After"] = "5"
+        return response
 
-    @app.errorhandler(exc.SQLAlchemyError)
-    def rollback_failed_transactoins(error):
-        app.logger.error(error)
-        db.session.rollback()
+    app.register_error_handler(exc.PendingRollbackError, _database_unavailable)
+    app.register_error_handler(exc.SQLAlchemyError, _database_unavailable)

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -36,7 +36,6 @@ from sqlalchemy import exc
 from sqlalchemy.sql import Update, Delete, Insert
 import os
 
-
 PRIMARY_DATABASE_URL = get_flask_env("DATABASE_URL", error=True)
 # Use the primary as the default
 REPLICA_ONE_DATABASE_URL = get_flask_env(

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -57,13 +57,10 @@ BASE_CONNECT_ARGS = {
     "keepalives_count": 3,
 }
 
-# statement_timeout sits below gunicorn's 30s worker timeout so Postgres
-# cancels the query and frees the connection before the worker is killed.
-# idle_in_transaction sits above it, so only abandoned transactions are
-# reaped. The primary gets no statement_timeout: bulk imports run long.
-READ_PG_OPTIONS = (
-    "-c statement_timeout=10000 -c idle_in_transaction_session_timeout=60000"
-)
+# idle_in_transaction reaps sessions a killed worker left mid-transaction.
+# Both sit above gunicorn's 30s timeout so only abandoned ones are hit.
+# No statement_timeout: reads legitimately run long in production.
+READ_PG_OPTIONS = "-c idle_in_transaction_session_timeout=60000"
 PRIMARY_PG_OPTIONS = "-c idle_in_transaction_session_timeout=300000"
 
 # max_connections is 100 and the fleet is 18 pods x 5 workers = 90

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -150,15 +150,32 @@ db = SQLAlchemy(
 )
 
 
+# Failures that a retry can plausibly clear: a dropped or timed-out
+# connection, an exhausted pool, a session left needing a rollback. Everything
+# else under SQLAlchemyError - ProgrammingError from schema drift,
+# IntegrityError from a constraint, DataError from a bad value - is permanent,
+# and telling a client to retry it produces a loop that never terminates.
+TRANSIENT_DB_ERRORS = (
+    exc.DisconnectionError,
+    exc.InterfaceError,
+    exc.OperationalError,
+    exc.PendingRollbackError,
+    exc.TimeoutError,
+)
+
+
 def init_db(app):
     db.init_app(app)
     Migrate(app, db)
 
-    # These handlers must return a response: returning None makes Flask
-    # raise a TypeError blaming the view, hiding the actual database error.
-    def _database_unavailable(error):
+    # Both handlers must return a response: returning None makes Flask raise a
+    # TypeError blaming the view, hiding the actual database error.
+    def _log_and_rollback(error):
         app.logger.error(error)
         db.session.rollback()
+
+    def _database_unavailable(error):
+        _log_and_rollback(error)
         response = make_response(
             jsonify(
                 {
@@ -173,5 +190,16 @@ def init_db(app):
         response.headers["Retry-After"] = "5"
         return response
 
-    app.register_error_handler(exc.PendingRollbackError, _database_unavailable)
-    app.register_error_handler(exc.SQLAlchemyError, _database_unavailable)
+    def _database_error(error):
+        # No Retry-After: these do not clear on their own.
+        _log_and_rollback(error)
+        return make_response(
+            jsonify({"message": "A database error occurred."}), 500
+        )
+
+    for error_type in TRANSIENT_DB_ERRORS:
+        app.register_error_handler(error_type, _database_unavailable)
+
+    # Flask dispatches to the most specific registered handler, so this stays
+    # the catch-all that guarantees a response for any other SQLAlchemyError.
+    app.register_error_handler(exc.SQLAlchemyError, _database_error)

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -48,9 +48,8 @@ REPLICA_TWO_DATABASE_URL = get_flask_env(
     PRIMARY_DATABASE_URL,
 )
 
-# connect_timeout bounds the handshake against a failed-over host that never
-# completes one; keepalives let the server reap backends stranded by
-# SIGKILLed workers.
+# connect_timeout bounds the handshake against a failed-over host; keepalives
+# let the server reap backends stranded by SIGKILLed workers.
 BASE_CONNECT_ARGS = {
     "connect_timeout": 5,
     "keepalives": 1,
@@ -59,19 +58,20 @@ BASE_CONNECT_ARGS = {
     "keepalives_count": 3,
 }
 
-# Server-side backstop for stranded backends; both values sit above
-# gunicorn's --timeout so only abandoned transactions are aborted (a CLI
-# import idling >5min mid-transaction will be too - raise PRIMARY_PG_OPTIONS).
+# statement_timeout sits below gunicorn's 30s worker timeout so Postgres
+# cancels the query and frees the connection before the worker is killed.
+# idle_in_transaction sits above it, so only abandoned transactions are
+# reaped. The primary gets no statement_timeout: bulk imports run long.
 READ_PG_OPTIONS = (
     "-c statement_timeout=10000 -c idle_in_transaction_session_timeout=60000"
 )
 PRIMARY_PG_OPTIONS = "-c idle_in_transaction_session_timeout=300000"
 
-# Sized against the server: max_connections is 100 and the fleet is 18 pods
-# x 5 workers = 90 processes, so pool_size 1 is the floor and cannot absorb
-# another worker increase. pool_timeout is short so an exhausted pool fails
-# fast instead of blocking into gunicorn's worker-timeout cascade.
-SQLALCHEMY_ENGINE_OPTIONS = {
+# max_connections is 100 and the fleet is 18 pods x 5 workers = 90
+# processes, so pool_size 1 is the floor and cannot absorb another worker
+# increase. Short pool_timeout fails fast instead of feeding gunicorn's
+# worker-timeout cascade.
+PRIMARY_ENGINE_OPTIONS = {
     "pool_recycle": 3600,
     "pool_pre_ping": True,
     "pool_size": 1,
@@ -80,11 +80,8 @@ SQLALCHEMY_ENGINE_OPTIONS = {
     "connect_args": {**BASE_CONNECT_ARGS, "options": PRIMARY_PG_OPTIONS},
 }
 
-# Reads are aborted by the database at 10s so a slow query frees its worker
-# and connection; the primary deliberately has no statement_timeout because
-# bulk CVE imports legitimately run long.
 READ_ENGINE_OPTIONS = {
-    **SQLALCHEMY_ENGINE_OPTIONS,
+    **PRIMARY_ENGINE_OPTIONS,
     "connect_args": {**BASE_CONNECT_ARGS, "options": READ_PG_OPTIONS},
 }
 
@@ -97,8 +94,8 @@ _replica_one_engine = create_engine(
     **READ_ENGINE_OPTIONS,
 )
 
-# The replica URLs fall back to DATABASE_URL when unset, so share one engine
-# while they match rather than doubling the connection count for one server.
+# Both replica URLs fall back to DATABASE_URL, so share one engine while they
+# match rather than doubling connections to the same server.
 if REPLICA_TWO_DATABASE_URL == REPLICA_ONE_DATABASE_URL:
     _replica_two_engine = _replica_one_engine
 else:
@@ -114,7 +111,7 @@ engines = {
 
 primary_engine = create_engine(
     url=PRIMARY_DATABASE_URL,
-    **SQLALCHEMY_ENGINE_OPTIONS,
+    **PRIMARY_ENGINE_OPTIONS,
 )
 
 
@@ -150,11 +147,9 @@ db = SQLAlchemy(
 )
 
 
-# Failures that a retry can plausibly clear: a dropped or timed-out
-# connection, an exhausted pool, a session left needing a rollback. Everything
-# else under SQLAlchemyError - ProgrammingError from schema drift,
-# IntegrityError from a constraint, DataError from a bad value - is permanent,
-# and telling a client to retry it produces a loop that never terminates.
+# Failures a retry can clear. Everything else under SQLAlchemyError
+# (ProgrammingError, IntegrityError, DataError) is permanent, and telling a
+# retrying client to come back produces a loop that never ends.
 TRANSIENT_DB_ERRORS = (
     exc.DisconnectionError,
     exc.InterfaceError,
@@ -165,11 +160,18 @@ TRANSIENT_DB_ERRORS = (
 
 
 def init_db(app):
+    # Flask-SQLAlchemy builds its own engine from SQLALCHEMY_DATABASE_URI for
+    # migrations and db.engine. RoutedSession never routes queries to it, but
+    # left unsized it defaults to 5+10 connections and no connect timeout.
+    app.config.setdefault(
+        "SQLALCHEMY_ENGINE_OPTIONS", dict(PRIMARY_ENGINE_OPTIONS)
+    )
+
     db.init_app(app)
     Migrate(app, db)
 
     # Both handlers must return a response: returning None makes Flask raise a
-    # TypeError blaming the view, hiding the actual database error.
+    # TypeError blaming the view and hiding the database error.
     def _log_and_rollback(error):
         app.logger.error(error)
         db.session.rollback()

--- a/webapp/database.py
+++ b/webapp/database.py
@@ -47,8 +47,7 @@ REPLICA_TWO_DATABASE_URL = get_flask_env(
     PRIMARY_DATABASE_URL,
 )
 
-# connect_timeout bounds the handshake against a failed-over host; keepalives
-# let the server reap backends stranded by SIGKILLed workers.
+# Give up on a dead host in 5s and let the server reap dead workers' backends.
 BASE_CONNECT_ARGS = {
     "connect_timeout": 5,
     "keepalives": 1,
@@ -57,16 +56,11 @@ BASE_CONNECT_ARGS = {
     "keepalives_count": 3,
 }
 
-# idle_in_transaction reaps sessions a killed worker left mid-transaction.
-# Both sit above gunicorn's 30s timeout so only abandoned ones are hit.
-# No statement_timeout: reads legitimately run long in production.
+# Above gunicorn's 30s timeout, so only abandoned transactions are reaped.
 READ_PG_OPTIONS = "-c idle_in_transaction_session_timeout=60000"
 PRIMARY_PG_OPTIONS = "-c idle_in_transaction_session_timeout=300000"
 
-# max_connections is 100 and the fleet is 18 pods x 5 workers = 90
-# processes, so pool_size 1 is the floor and cannot absorb another worker
-# increase. Short pool_timeout fails fast instead of feeding gunicorn's
-# worker-timeout cascade.
+# 90 workers share max_connections=100, so pool_size 1 is the ceiling.
 PRIMARY_ENGINE_OPTIONS = {
     "pool_recycle": 3600,
     "pool_pre_ping": True,
@@ -85,24 +79,21 @@ READ_ENGINE_OPTIONS = {
 REPLICA_ONE = "replicaone"
 REPLICA_TWO = "replicatwo"
 
-_replica_one_engine = create_engine(
-    url=REPLICA_ONE_DATABASE_URL,
-    **READ_ENGINE_OPTIONS,
-)
+_read_engines_by_url = {}
 
-# Both replica URLs fall back to DATABASE_URL, so share one engine while they
-# match rather than doubling connections to the same server.
-if REPLICA_TWO_DATABASE_URL == REPLICA_ONE_DATABASE_URL:
-    _replica_two_engine = _replica_one_engine
-else:
-    _replica_two_engine = create_engine(
-        url=REPLICA_TWO_DATABASE_URL,
-        **READ_ENGINE_OPTIONS,
-    )
+
+# Replicas that resolve to the same URL share one engine.
+def _read_engine(url):
+    if url not in _read_engines_by_url:
+        _read_engines_by_url[url] = create_engine(
+            url=url, **READ_ENGINE_OPTIONS
+        )
+    return _read_engines_by_url[url]
+
 
 engines = {
-    REPLICA_ONE: _replica_one_engine,
-    REPLICA_TWO: _replica_two_engine,
+    REPLICA_ONE: _read_engine(REPLICA_ONE_DATABASE_URL),
+    REPLICA_TWO: _read_engine(REPLICA_TWO_DATABASE_URL),
 }
 
 primary_engine = create_engine(
@@ -143,9 +134,7 @@ db = SQLAlchemy(
 )
 
 
-# Failures a retry can clear. Everything else under SQLAlchemyError
-# (ProgrammingError, IntegrityError, DataError) is permanent, and telling a
-# retrying client to come back produces a loop that never ends.
+# Errors a retry can clear; the rest under SQLAlchemyError are permanent.
 TRANSIENT_DB_ERRORS = (
     exc.DisconnectionError,
     exc.InterfaceError,
@@ -156,9 +145,7 @@ TRANSIENT_DB_ERRORS = (
 
 
 def init_db(app):
-    # Flask-SQLAlchemy builds its own engine from SQLALCHEMY_DATABASE_URI for
-    # migrations and db.engine. RoutedSession never routes queries to it, but
-    # left unsized it defaults to 5+10 connections and no connect timeout.
+    # Size Flask-SQLAlchemy's own engine like the others.
     app.config.setdefault(
         "SQLALCHEMY_ENGINE_OPTIONS", dict(PRIMARY_ENGINE_OPTIONS)
     )
@@ -166,8 +153,7 @@ def init_db(app):
     db.init_app(app)
     Migrate(app, db)
 
-    # Both handlers must return a response: returning None makes Flask raise a
-    # TypeError blaming the view and hiding the database error.
+    # Returning None makes Flask raise a TypeError that hides the real error.
     def _log_and_rollback(error):
         app.logger.error(error)
         db.session.rollback()
@@ -189,7 +175,6 @@ def init_db(app):
         return response
 
     def _database_error(error):
-        # No Retry-After: these do not clear on their own.
         _log_and_rollback(error)
         return make_response(
             jsonify({"message": "A database error occurred."}), 500
@@ -198,6 +183,5 @@ def init_db(app):
     for error_type in TRANSIENT_DB_ERRORS:
         app.register_error_handler(error_type, _database_unavailable)
 
-    # Flask dispatches to the most specific registered handler, so this stays
-    # the catch-all that guarantees a response for any other SQLAlchemyError.
+    # Catch-all so every other SQLAlchemyError still gets a response.
     app.register_error_handler(exc.SQLAlchemyError, _database_error)

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -27,7 +27,6 @@ from webapp.types import (
     PRIORITY_OPTIONS,
 )
 
-
 notice_cves = Table(
     "notice_cves",
     db.Model.metadata,


### PR DESCRIPTION
## Done

- Database error handlers return a 503 with `Retry-After` instead of `None`, which made Flask raise a `TypeError` that hid the real error
- Only transient errors (dropped connection, exhausted pool, pending rollback) get `Retry-After`. Schema drift and constraint violations return 500, so the retrying importer does not loop
- `connect_timeout=5` and TCP keepalives on every engine. A dead host fails in 5s instead of hanging
- Flask-SQLAlchemy's own engine gets the same pool sizing as the hand-built ones. It was at library defaults
- Sentry stops serialising view locals, which was failing on ORM objects
- Drive-by: replicas that resolve to the same URL share one engine

Same as #295 minus the 10s read `statement_timeout`. Production logs show 374 requests an hour legitimately over 10s.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

Each step below prints a number. The `main` column is what you get on `main` with the same command.

**Dead host gives up in 5s.** With `DATABASE_URL=postgresql://u:p@10.255.255.1:5432/x`:

```bash
timeout 60 python3 -c "
import time; from webapp import database as D
t=time.time()
try: D.primary_engine.connect()
except Exception as e: print(f'{time.time()-t:.1f}s {type(e).__name__}')" || echo "hung for 60s, killed"
```

| branch | main |
|---|---|
| `5.0s OperationalError` | `hung for 60s, killed` |

**All three engines carry the same settings.** With `DATABASE_URL` pointing at a running database:

```bash
python3 -c "
from sqlalchemy import text
from webapp.app import app; from webapp import database as D
def show(n,e):
    p=e.pool
    with e.connect() as c: it=c.execute(text('SHOW idle_in_transaction_session_timeout')).scalar()
    print(f'{n:9} pool={p.size()}/{p._max_overflow} timeout={p._timeout} idle_in_txn={it}')
show('replica',D.engines[D.REPLICA_ONE]); show('primary',D.primary_engine)
with app.app_context(): show('flask-sa',D.db.engine)"
```

| engine | branch | main |
|---|---|---|
| replica | `pool=1/2 timeout=5 idle_in_txn=1min` | `pool=5/10 timeout=30.0 idle_in_txn=0` |
| primary | `pool=1/2 timeout=5 idle_in_txn=5min` | `pool=5/10 timeout=30.0 idle_in_txn=0` |
| flask-sa | `pool=1/2 timeout=5 idle_in_txn=5min` | `pool=5/10 timeout=30.0 idle_in_txn=0` |

**A dead database returns 503 with Retry-After.** Start the site, stop the database, then:

```bash
curl -s -o /dev/null -w '%{http_code} retry-after=%header{retry-after}\n' http://0.0.0.0:8030/security/cves.json?limit=1
```

| branch | main |
|---|---|
| `503 retry-after=5` | `500 retry-after=` |

## Issue / Card

Supersedes #295. Addresses Sentry UBUNTU-COM-SECURITY-API-Q, -50 and -QF.

## Screenshots

Not relevant (API-only change).
