### PR TITLE
Compress JSON responses, except for the Pro client

### DIFF
--- a/tests/test_response_compression.py
+++ b/tests/test_response_compression.py
@@ -24,9 +24,7 @@ class ResponseCompression(BaseTestCase):
 
     def test_body_survives_a_round_trip(self):
         plain = self.client.get(self.URL)
-        packed = self.client.get(
-            self.URL, headers={"Accept-Encoding": "gzip"}
-        )
+        packed = self.client.get(self.URL, headers={"Accept-Encoding": "gzip"})
         self.assertEqual(gzip.decompress(packed.data), plain.data)
 
     def test_pro_client_is_never_compressed(self):

--- a/tests/test_response_compression.py
+++ b/tests/test_response_compression.py
@@ -6,9 +6,14 @@ API serves went out uncompressed. These pin the behaviour back.
 
 Compression is negotiated: a client that sends no Accept-Encoding still gets
 the plain body, so the API contract is unchanged either way.
+
+The Ubuntu Pro client is the one known exception. It reads the raw body as
+UTF-8 without honouring Content-Encoding, which is why compression was
+disabled in the first place (WD-23733). It is exempted by User-Agent.
 """
 
 import gzip
+import json
 
 from tests import BaseTestCase
 
@@ -30,6 +35,19 @@ class ResponseCompression(BaseTestCase):
             self.URL, headers={"Accept-Encoding": "gzip"}
         )
         self.assertEqual(gzip.decompress(packed.data), plain.data)
+
+    def test_pro_client_is_never_compressed(self):
+        response = self.client.get(
+            self.URL,
+            headers={
+                "Accept-Encoding": "gzip",
+                "User-Agent": "UA-Client/37.2ubuntu~22.04.1",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.headers.get("Content-Encoding"))
+        # What `pro fix` does with the body: decode it as UTF-8 directly.
+        json.loads(response.data.decode("utf-8"))
 
     def test_client_without_accept_encoding_gets_plain_json(self):
         response = self.client.get(self.URL)

--- a/tests/test_response_compression.py
+++ b/tests/test_response_compression.py
@@ -1,15 +1,8 @@
-"""JSON responses must be compressed when the client accepts it.
+"""JSON responses are compressed when the client accepts it, except for the
+Ubuntu Pro client, which reads the raw body as UTF-8 (WD-23733).
 
-webapp/app.py used to pass flask-compress a mimetype list that was the
-library's own default with application/json deleted, so every response this
-API serves went out uncompressed. These pin the behaviour back.
-
-Compression is negotiated: a client that sends no Accept-Encoding still gets
-the plain body, so the API contract is unchanged either way.
-
-The Ubuntu Pro client is the one known exception. It reads the raw body as
-UTF-8 without honouring Content-Encoding, which is why compression was
-disabled in the first place (WD-23733). It is exempted by User-Agent.
+A client that sends no Accept-Encoding gets the plain body, so the contract
+is unchanged.
 """
 
 import gzip
@@ -46,7 +39,7 @@ class ResponseCompression(BaseTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.headers.get("Content-Encoding"))
-        # What `pro fix` does with the body: decode it as UTF-8 directly.
+        # Mirrors what pro fix does with the body.
         json.loads(response.data.decode("utf-8"))
 
     def test_client_without_accept_encoding_gets_plain_json(self):

--- a/tests/test_response_compression.py
+++ b/tests/test_response_compression.py
@@ -1,0 +1,37 @@
+"""JSON responses must be compressed when the client accepts it.
+
+webapp/app.py used to pass flask-compress a mimetype list that was the
+library's own default with application/json deleted, so every response this
+API serves went out uncompressed. These pin the behaviour back.
+
+Compression is negotiated: a client that sends no Accept-Encoding still gets
+the plain body, so the API contract is unchanged either way.
+"""
+
+import gzip
+
+from tests import BaseTestCase
+
+
+class ResponseCompression(BaseTestCase):
+    # flask-compress leaves anything under COMPRESS_MIN_SIZE (500) alone.
+    URL = "/security/cves.json?limit=10"
+
+    def test_json_is_gzipped_when_accepted(self):
+        response = self.client.get(
+            self.URL, headers={"Accept-Encoding": "gzip"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("Content-Encoding"), "gzip")
+
+    def test_body_survives_a_round_trip(self):
+        plain = self.client.get(self.URL)
+        packed = self.client.get(
+            self.URL, headers={"Accept-Encoding": "gzip"}
+        )
+        self.assertEqual(gzip.decompress(packed.data), plain.data)
+
+    def test_client_without_accept_encoding_gets_plain_json(self):
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.headers.get("Content-Encoding"))

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -36,67 +36,11 @@ from webapp.views import (
     update_release,
 )
 
-# Flask compress options
-COMPRESS_MIMETYPES = [
-    "text/html",
-    "text/css",
-    "text/plain",
-    "text/xml",
-    "text/x-component",
-    "text/javascript",
-    "application/x-javascript",
-    "application/javascript",
-    "application/manifest+json",
-    "application/vnd.api+json",
-    "application/xml",
-    "application/xhtml+xml",
-    "application/rss+xml",
-    "application/atom+xml",
-    "application/vnd.ms-fontobject",
-    "application/x-font-ttf",
-    "application/x-font-opentype",
-    "application/x-font-truetype",
-    "image/svg+xml",
-    "image/x-icon",
-    "image/vnd.microsoft.icon",
-    "font/ttf",
-    "font/eot",
-    "font/otf",
-    "font/opentype",
-]
-
-# Flask compress options
-COMPRESS_MIMETYPES = [
-    "text/html",
-    "text/css",
-    "text/plain",
-    "text/xml",
-    "text/x-component",
-    "text/javascript",
-    "application/x-javascript",
-    "application/javascript",
-    "application/manifest+json",
-    "application/vnd.api+json",
-    "application/xml",
-    "application/xhtml+xml",
-    "application/rss+xml",
-    "application/atom+xml",
-    "application/vnd.ms-fontobject",
-    "application/x-font-ttf",
-    "application/x-font-opentype",
-    "application/x-font-truetype",
-    "image/svg+xml",
-    "image/x-icon",
-    "image/vnd.microsoft.icon",
-    "font/ttf",
-    "font/eot",
-    "font/otf",
-    "font/opentype",
-]
-
-app = FlaskBase(
-    __name__, "ubuntu-com-security-api", compress_mimetypes=COMPRESS_MIMETYPES
-)
+# No compress_mimetypes: flask-compress's default list already covers
+# everything this API serves, application/json included. The list this file
+# used to pass was that default with application/json deleted, which left
+# every JSON response uncompressed.
+app = FlaskBase(__name__, "ubuntu-com-security-api")
 
 app.config.update(
     {

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -36,21 +36,15 @@ from webapp.views import (
     update_release,
 )
 
-# No compress_mimetypes: flask-compress's default list already covers
-# everything this API serves, application/json included. The list this file
-# used to pass was that default with application/json deleted, which left
-# every JSON response uncompressed.
+# flask-compress's default mimetypes already include application/json.
 app = FlaskBase(__name__, "ubuntu-com-security-api")
 
-# The Ubuntu Pro client reads the raw body as UTF-8 without honouring
-# Content-Encoding, so a compressed response breaks `pro fix` (WD-23733).
-# Drop its Accept-Encoding before flask-compress sees it; every other client
-# gets negotiated compression as normal.
+# The Pro client reads raw bytes as UTF-8, so it cannot take gzip (WD-23733).
 UNCOMPRESSED_USER_AGENTS = ("UA-Client/",)
 
 
 @app.before_request
-def _no_compression_for_clients_that_cannot_decode_it():
+def skip_compression_for_unsupported_clients():
     if request.headers.get("User-Agent", "").startswith(
         UNCOMPRESSED_USER_AGENTS
     ):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -3,7 +3,7 @@ import os
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from canonicalwebteam.flask_base.app import FlaskBase
-from flask import jsonify, make_response
+from flask import request, jsonify, make_response
 from canonicalwebteam.flask_base.env import get_flask_env
 from sentry_sdk.integrations.flask import FlaskIntegration
 import sentry_sdk
@@ -41,6 +41,21 @@ from webapp.views import (
 # used to pass was that default with application/json deleted, which left
 # every JSON response uncompressed.
 app = FlaskBase(__name__, "ubuntu-com-security-api")
+
+# The Ubuntu Pro client reads the raw body as UTF-8 without honouring
+# Content-Encoding, so a compressed response breaks `pro fix` (WD-23733).
+# Drop its Accept-Encoding before flask-compress sees it; every other client
+# gets negotiated compression as normal.
+UNCOMPRESSED_USER_AGENTS = ("UA-Client/",)
+
+
+@app.before_request
+def _no_compression_for_clients_that_cannot_decode_it():
+    if request.headers.get("User-Agent", "").startswith(
+        UNCOMPRESSED_USER_AGENTS
+    ):
+        request.environ.pop("HTTP_ACCEPT_ENCODING", None)
+
 
 app.config.update(
     {


### PR DESCRIPTION
## Done

- JSON responses are compressed again. `COMPRESS_MIMETYPES` was flask-compress's default list with `application/json` removed, pasted twice. Both copies are gone and the library default applies
- The Ubuntu Pro client is exempted by User-Agent. It reads the raw body as UTF-8 without honouring `Content-Encoding`, which is why compression was disabled in #206 (WD-23733). It is under 1% of requests
- No contract change. Compression is negotiated on `Accept-Encoding`, and the exempted client gets the same bytes as today

Requests over 1MB are 7.6% of traffic and 53% of worker time (one pod, one hour). gzip costs about 175ms for an 8MB body.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8030/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

**Measure the saving on real data.** Production is uncompressed today, so fetch a live response and gzip it. This needs no local setup and shows exactly what this PR saves:

```bash
for p in '/security/cves.json?package=linux&limit=10&order=newest' \
         '/security/cves/CVE-2025-38346.json' \
         '/security/notices.json?limit=10'; do
  curl -s -H 'Accept-Encoding: identity' "https://ubuntu.com$p" -o body.json
  printf '%-56s %10s -> %8s bytes\n' "$p" "$(wc -c < body.json)" "$(gzip -6 -c body.json | wc -c)"
done
```

Measured 2026-09-07:

| endpoint | plain | gzip | ratio |
|---|---|---|---|
| `cves.json?package=linux&limit=10&order=newest` | 1,365,738 | 50,785 | 3.7% |
| `cves/CVE-2025-38346.json` | 1,679,941 | 164,466 | 9.8% |
| `notices.json?limit=10` | 1,001,699 | 60,726 | 6.1% |

**Confirm the branch does it.** Against the local site:

```bash
U='http://0.0.0.0:8030/security/cves.json?limit=10'
curl -s -o /dev/null -w 'no header:   %{size_download} bytes  encoding=%header{content-encoding}\n' "$U"
curl -s -o /dev/null -w 'gzip:        %{size_download} bytes  encoding=%header{content-encoding}\n' -H 'Accept-Encoding: gzip' "$U"
curl -s -o /dev/null -w 'pro client:  %{size_download} bytes  encoding=%header{content-encoding}\n' -H 'Accept-Encoding: gzip' -H 'User-Agent: UA-Client/37.2ubuntu~22.04.1' "$U"
```

Expect `encoding=gzip` and a smaller byte count on the second line only. Lines one and three match each other exactly. On `main` all three lines match.

**After deploy.** `curl -sI --compressed https://ubuntu.com/security/notices.json?limit=10 | grep -i content-encoding` shows `gzip` (or `br`/`zstd`, whichever the client negotiates). Today it shows nothing.

## Issue / Card

Revisits WD-23733 / #206. The Pro client on `main` sends no `Accept-Encoding` of its own. The exemption holds as long as it forwards the User-Agent.

## Screenshots

Not relevant (API-only change).
